### PR TITLE
UIG-43

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,17 +13,6 @@ RUN git clone ${REPO} app
 
 WORKDIR /home/node/app
 
-# /etc/hosts aanpassing:
-# de nieuwe npmrc heeft repository.milieuinfo.be in zijn non proxy hosts staan
-# vermits dat een host is die op internet is ontsloten en we willen vermijden 
-# dat alle builds via de forward proxy naar buiten moeten om dan terug naar 
-# binnen te gaan hebben we artifactory via de loadbalancer aangeboden in het 
-# VLAN van de bamboos maar vermits repository.milieuinfo.be verwijst naar een 
-# extern ip en niet naar het interne LB adres moeten we het in /etc/hosts zetten
-# natuurlijk als je met docker werkt zal dat niet werken want die heeft 
-# zijn eigen etc hosts dus als je het wil laten werken moet je die zelf aanmaken
-
-RUN echo '10.48.0.203 repository.milieuinfo.be' >> /etc/hosts \
-    && npm install \
+RUN npm install \
     && npm run release:prepare \
     && npm run release:testless -- ${VERSION}

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -19,10 +19,17 @@ services:
       - HUB_PORT_4444_TCP_PORT=4444
   tests:
     image: ${DOCKER_REGISTRY}node:12
+    command: bash -c "cp -R /data/. /workdir && npm install && npm run test"
     depends_on:
       - selenium-hub
       - selenium-chrome
       - selenium-firefox
+    environment: 
+      - http_proxy=${http_proxy}
+      - https_proxy=${https_proxy}
+      - no_proxy=${no_proxy},selenium-hub,host
+    extra_hosts:
+      - "repository.milieuinfo.be:${REPOSITORY_FIXED_IP}"
     working_dir: /workdir
     volumes:
       - ${HOME:-.}/.npmrc:/root/.npmrc:ro
@@ -30,9 +37,6 @@ services:
       - ${HOME:-.}/.git-credentials:/root/.git-credentials:ro
       - ..:/data:ro
       - ./wct.docker.conf.json:/workdir/wct.conf.json:ro
-    command: bash -c "cp -R /data/. /workdir && npm install && npm run test"
-    extra_hosts:
-      - "repository.milieuinfo.be:${REPOSITORY_FIXED_IP}"
 networks:
   build-network:
     driver: bridge


### PR DESCRIPTION
- Proxy settings toegevoegd aan docker-compose zodat sauce-connect en chromedriver kunnen gedownload worden tijdens `npm install`

- Proxy settings verwijderd uit de Dockerfile. Deze dienen doorgegeven te worden als build-arg zodat alle NPM packages, die het ondersteunen, de http_proxy en https-proxy overnemen.