### PR TITLE
Verwijder Docker config uit dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,10 +7,3 @@ update_configs:
       - "coemans"
     directory: "/"
     update_schedule: "live"
-  - package_manager: "docker"
-    default_assignees:
-      - "coemans"
-    default_reviewers:
-      - "coemans"
-    directory: "/"
-    update_schedule: "weekly"


### PR DESCRIPTION
Dockerfile is niet meer aanwezig in de projecten, dus dependabot dient dit ook niet meer te controleren.