### PR TITLE
Maak script aan om README in elke component te updaten

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "install:font:vlaanderen-icon": "replace '/font/iconfont/vlaanderen-icon.woff' 'https://cdn.milieuinfo.be/vlaanderen-font/LATEST/font/iconfont/3.9.1/vlaanderen-icon.woff' ../../style.css",
     "release": "np",
     "release:prepare": "echo 2Fabiola for the bigger and bolder",
-    "release:testless": "np --yolo"
+    "release:testless": "np --yolo",
+    "update:readme": "./scripts/updateReadme.sh"
   },
   "dependencies": {
     "prismjs": "1.17.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "release": "np",
     "release:prepare": "echo 2Fabiola for the bigger and bolder",
     "release:testless": "np --yolo",
-    "update:readme": "./scripts/updateReadme.sh"
+    "update:readme": ". ./scripts/updateReadme.sh"
   },
   "dependencies": {
     "prismjs": "1.17.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "publishConfig": {
     "registry": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/"
   },
+  "config": {
+    "script-shell": "bash" 
+  },
   "scripts": {
     "util": "npm run install:sass && npm run install:copy && npm run install:fonts && npm run install:bamboo && npm run install:copy:github",
     "install:utils": "npm run install:bamboo && npm run install:copy:install && npm run install:copy:codeowner && npm run install:copy:github",
@@ -36,7 +39,7 @@
     "release": "np",
     "release:prepare": "echo 2Fabiola for the bigger and bolder",
     "release:testless": "np --yolo",
-    "update:readme": ". ./scripts/updateReadme.sh"
+    "update:readme": "bash ./scripts/updateReadme.sh"
   },
   "dependencies": {
     "prismjs": "1.17.1",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "Hello"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Hello"

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -45,8 +45,8 @@ installJqDependency
 copyTemplate
 
 # Populate variables
-description=$(cat ../../package.json | jq '.description')
-componentFullName=$(cat ../../package.json | jq '.name') #vl-ui-template
+description=$(cat ../../package.json | jq --raw-output '.description')
+componentFullName=$(cat ../../package.json | jq --raw-output '.name') #vl-ui-template
 apiName=$(getApiName ${componentFullName})
 demoName=$(getDemoName ${componentFullName})
 

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -7,7 +7,6 @@ set -e
 #################################################################################################
 
 CWD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-echo ${CWD}
 
 installJqDependency() {
     which -s jq
@@ -58,5 +57,5 @@ sed -i "" -e "s/@apiName@/${apiName}/g" README.md.template
 sed -i "" -e "s/@demoName@/${demoName}/g" README.md.template
 
 # Clean up after ourselves
-rm -rfv README.md
-mv -fv README.md.template ${CWD}/README.new.md
+rm -rf README.md
+mv -fv README.md.template ../../../README.new.md

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -31,7 +31,7 @@ getDemoName() {
 }
 
 copyTemplate() { 
-    cp ${CWD}/templates/README.md.template README.md.template
+    cp ${CWD}/../templates/README.md.template README.md.template
 }
 
 #################################################################################################

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -19,7 +19,7 @@ getApiName() {
     IFS='-' # hyphen (-) is set as delimiter
         read -ra array <<< "$1" # str is read into an array as tokens separated by IFS
         for i in "${array[@]}"; do # access each element of array
-            output+=$(printf %s "$1" | sed -E 's/(^|-+)(.)/\U\2/g') #set first letter to uppercase
+            output+=${i^} #set first letter to uppercase
         done
     IFS=' '
     echo ${output}
@@ -32,7 +32,7 @@ getDemoName() {
 }
 
 copyTemplate() { 
-    cp ${CWD}/../templates/README.md.template README.md.template
+    cp ${CWD}/templates/README.md.template README.md.template
 }
 
 #################################################################################################

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -7,6 +7,7 @@ set -e
 #################################################################################################
 
 CWD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+echo ${CWD}
 
 installJqDependency() {
     which -s jq
@@ -57,5 +58,5 @@ sed -i "" -e "s/@apiName@/${apiName}/g" README.md.template
 sed -i "" -e "s/@demoName@/${demoName}/g" README.md.template
 
 # Clean up after ourselves
-rm -rf README.md
-mv -fv README.md.template README.new.md
+rm -rfv README.md
+mv -fv README.md.template ${CWD}/README.new.md

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+#################################################################################################
+#                                       Helper functions                                        #
+#################################################################################################
+
 CWD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 installJqDependency() {
@@ -12,8 +16,11 @@ installJqDependency() {
 
 getApiName() {
     IFS='-' # hyphen (-) is set as delimiter
-        read -ra ADDR <<< "$1" # str is read into an array as tokens separated by IFS
+        read -ra ADDR <<< "${1}" # str is read into an array as tokens separated by IFS
+        echo ${1}
+        echo ${ADDR}
         for i in "${ADDR[@]}"; do # access each element of array
+            echo ${apiName}
             apiName+=${i^} #set first letter to uppercase
         done
     IFS=' '
@@ -30,16 +37,26 @@ copyTemplate() {
     cp ${CWD}/../templates/README.md.template README.md.template
 }
 
+#################################################################################################
+#                                   Application logic                                           #
+#################################################################################################
+
+# Get everything ready
 installJqDependency
 copyTemplate
 
+# Populate variables
 description=$(cat ../../package.json | jq '.description')
 componentFullName=$(cat ../../package.json | jq '.name') #vl-ui-template
 apiName=$(getApiName ${componentFullName})
 demoName=$(getDemoName ${componentFullName})
 
+# Replace all template occurances with correct value
 sed -i "" -e "s/@description@/${description}/g" README.md.template
 sed -i "" -e "s/@fullName@/${componentFullName}/g" README.md.template
 sed -i "" -e "s/@apiName@/${apiName}/g" README.md.template
 sed -i "" -e "s/@demoName@/${demoName}/g" README.md.template
 
+# Clean up after ourselves
+rm -rf README.md
+mv README.md.template README.md

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+prepareEnvironment() {
+    which -s jq
+    if [[ $? != 0 ]] ; then
+        echo "Jq is not installed, please hang on while we install it for you ..."
+        brew install jq
+    fi
+}
+
+cp ../templates/README.md.template ../../../README.md.template
+description=$(cat ../../../package.json | jq '.description')
+echo ${description}
+
+#replaceDescription() {
+#    sed -i "" -e "s/@description@/${description}/g" $fullPath/README.md.template
+#    touch $fullPath/package.new.json
+#    cat package.json | jq --arg desc "${description}" '.description = $desc' > $fullPath/package.new.json
+#}

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -27,7 +27,7 @@ getDemoName() {
 }
 
 copyTemplate() { 
-    cp ${CWD}/node_modules/vl-ui-util/templates/README.md.template README.md.template
+    cp ${CWD}../templates/README.md.template README.md.template
 }
 
 installJqDependency
@@ -38,8 +38,8 @@ componentFullName=$(cat ../../package.json | jq '.name') #vl-ui-template
 apiName=$(getApiName ${componentFullName})
 demoName=$(getDemoName ${componentFullName})
 
-sed -i "" -e "s/@description@/${description}/g" ${CWD}/README.md.template
-sed -i "" -e "s/@fullName@/${componentFullName}/g" ${CWD}/README.md.template
-sed -i "" -e "s/@apiName@/${apiName}/g" ${CWD}/README.md.template
-sed -i "" -e "s/@demoName@/${demoName}/g" ${CWD}/README.md.template
+sed -i "" -e "s/@description@/${description}/g" README.md.template
+sed -i "" -e "s/@fullName@/${componentFullName}/g" README.md.template
+sed -i "" -e "s/@apiName@/${apiName}/g" README.md.template
+sed -i "" -e "s/@demoName@/${demoName}/g" README.md.template
 

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+ps
+
 #################################################################################################
 #                                       Helper functions                                        #
 #################################################################################################
@@ -18,7 +20,7 @@ getApiName() {
     IFS='-' # hyphen (-) is set as delimiter
         read -ra array <<< "$1" # str is read into an array as tokens separated by IFS
         for i in "${array[@]}"; do # access each element of array
-            output+=${i^} #set first letter to uppercase
+            output+=$(printf %s "$1" | sed -E 's/(^|-+)(.)/\U\2/g') #set first letter to uppercase
         done
     IFS=' '
     echo ${output}

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -1,6 +1,5 @@
+bash -s -- "$@" <<"EOF"
 #!/usr/bin/env bash
-
-ps
 
 #################################################################################################
 #                                       Helper functions                                        #
@@ -59,3 +58,4 @@ sed -i "" -e "s/@demoName@/${demoName}/g" README.md.template
 # Clean up after ourselves
 rm -rf README.md
 mv README.md.template README.md
+EOF

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -27,7 +27,7 @@ getDemoName() {
 }
 
 copyTemplate() { 
-    cp ${CWD}../templates/README.md.template README.md.template
+    cp ${CWD}/../templates/README.md.template README.md.template
 }
 
 installJqDependency

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 #################################################################################################
 #                                       Helper functions                                        #
 #################################################################################################
@@ -56,4 +58,4 @@ sed -i "" -e "s/@demoName@/${demoName}/g" README.md.template
 
 # Clean up after ourselves
 rm -rf README.md
-mv README.md.template README.new.md
+mv -fv README.md.template README.new.md

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -16,15 +16,12 @@ installJqDependency() {
 
 getApiName() {
     IFS='-' # hyphen (-) is set as delimiter
-        read -ra ADDR <<< "${1}" # str is read into an array as tokens separated by IFS
-        echo ${1}
-        echo ${ADDR}
-        for i in "${ADDR[@]}"; do # access each element of array
-            echo ${apiName}
-            apiName+=${i^} #set first letter to uppercase
+        read -ra array <<< "$1" # str is read into an array as tokens separated by IFS
+        for i in "${array[@]}"; do # access each element of array
+            output+=${i^} #set first letter to uppercase
         done
     IFS=' '
-    echo ${apiName}
+    echo ${output}
 }
 
 getDemoName() {

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -20,15 +20,15 @@ getApiName() {
     IFS='-' # hyphen (-) is set as delimiter
         read -ra array <<< "$1" # str is read into an array as tokens separated by IFS
         for i in "${array[@]}"; do # access each element of array
-            output+=${i^} #set first letter to uppercase
+            output+=${i^} # set first letter to uppercase
         done
     IFS=' '
-    echo ${output}
+    echo "${output//Ui}" # strip Ui from string
 }
 
 getDemoName() {
-    vl=$(echo ${1} | cut -c1-2)
-    template=$(echo ${1} | cut -c7-)
+    vl=$(echo ${1} | cut -c1-2) # get first two characters
+    template=$(echo ${1} | cut -c7-) # get 7th character untill final
     echo ${vl}-${template}
 }
 
@@ -46,7 +46,7 @@ copyTemplate
 
 # Populate variables
 description=$(cat ../../package.json | jq --raw-output '.description')
-componentFullName=$(cat ../../package.json | jq --raw-output '.name') #vl-ui-template
+componentFullName=$(cat ../../package.json | jq --raw-output '.name')
 apiName=$(getApiName ${componentFullName})
 demoName=$(getDemoName ${componentFullName})
 

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+CWD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
 installJqDependency() {
     which -s jq
     if [[ $? != 0 ]] ; then
@@ -25,7 +27,7 @@ getDemoName() {
 }
 
 copyTemplate() { 
-    cp node_modules/vl-ui-util/templates/README.md.template README.md.template
+    cp ${CWD}/node_modules/vl-ui-util/templates/README.md.template README.md.template
 }
 
 installJqDependency
@@ -36,8 +38,8 @@ componentFullName=$(cat ../../package.json | jq '.name') #vl-ui-template
 apiName=$(getApiName ${componentFullName})
 demoName=$(getDemoName ${componentFullName})
 
-sed -i "" -e "s/@description@/${description}/g" README.md.template
-sed -i "" -e "s/@fullName@/${componentFullName}/g" README.md.template
-sed -i "" -e "s/@apiName@/${apiName}/g" README.md.template
-sed -i "" -e "s/@demoName@/${demoName}/g" README.md.template
+sed -i "" -e "s/@description@/${description}/g" ${CWD}/README.md.template
+sed -i "" -e "s/@fullName@/${componentFullName}/g" ${CWD}/README.md.template
+sed -i "" -e "s/@apiName@/${apiName}/g" ${CWD}/README.md.template
+sed -i "" -e "s/@demoName@/${demoName}/g" ${CWD}/README.md.template
 

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -57,5 +57,5 @@ sed -i "" -e "s/@apiName@/${apiName}/g" README.md.template
 sed -i "" -e "s/@demoName@/${demoName}/g" README.md.template
 
 # Clean up after ourselves
-rm -rf README.md
-mv -fv README.md.template ../../../README.new.md
+rm -rf ../../README.md
+mv -fv README.md.template ../../README.md

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -1,4 +1,3 @@
-bash -s -- "$@" <<"EOF"
 #!/usr/bin/env bash
 
 #################################################################################################
@@ -57,5 +56,4 @@ sed -i "" -e "s/@demoName@/${demoName}/g" README.md.template
 
 # Clean up after ourselves
 rm -rf README.md
-mv README.md.template README.md
-EOF
+mv README.md.template README.new.md

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-prepareEnvironment() {
+installJqDependency() {
     which -s jq
     if [[ $? != 0 ]] ; then
         echo "Jq is not installed, please hang on while we install it for you ..."
@@ -8,12 +8,36 @@ prepareEnvironment() {
     fi
 }
 
-cp ../../templates/README.md.template README.md.template
-description=$(cat ../../package.json | jq '.description')
-echo ${description}
+getApiName() {
+    IFS='-' # hyphen (-) is set as delimiter
+        read -ra ADDR <<< "$1" # str is read into an array as tokens separated by IFS
+        for i in "${ADDR[@]}"; do # access each element of array
+            apiName+=${i^} #set first letter to uppercase
+        done
+    IFS=' '
+    echo ${apiName}
+}
 
-#replaceDescription() {
-#    sed -i "" -e "s/@description@/${description}/g" $fullPath/README.md.template
-#    touch $fullPath/package.new.json
-#    cat package.json | jq --arg desc "${description}" '.description = $desc' > $fullPath/package.new.json
-#}
+getDemoName() {
+    vl=$(echo ${1} | cut -c1-2)
+    template=$(echo ${1} | cut -c7-)
+    echo ${vl}-${template}
+}
+
+copyTemplate() { 
+    cp node_modules/vl-ui-util/templates/README.md.template README.md.template
+}
+
+installJqDependency
+copyTemplate
+
+description=$(cat ../../package.json | jq '.description')
+componentFullName=$(cat ../../package.json | jq '.name') #vl-ui-template
+apiName=$(getApiName ${componentFullName})
+demoName=$(getDemoName ${componentFullName})
+
+sed -i "" -e "s/@description@/${description}/g" README.md.template
+sed -i "" -e "s/@fullName@/${componentFullName}/g" README.md.template
+sed -i "" -e "s/@apiName@/${apiName}/g" README.md.template
+sed -i "" -e "s/@demoName@/${demoName}/g" README.md.template
+

--- a/scripts/updateReadme.sh
+++ b/scripts/updateReadme.sh
@@ -8,8 +8,8 @@ prepareEnvironment() {
     fi
 }
 
-cp ../templates/README.md.template ../../../README.md.template
-description=$(cat ../../../package.json | jq '.description')
+cp ../../templates/README.md.template README.md.template
+description=$(cat ../../package.json | jq '.description')
 echo ${description}
 
 #replaceDescription() {

--- a/templates/README.md.template
+++ b/templates/README.md.template
@@ -1,0 +1,52 @@
+# vl-template
+![GitHub issues](https://img.shields.io/github/issues-raw/milieuinfo/webcomponent-vl-ui-template) ![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/milieuinfo/webcomponent-vl-ui-template) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/milieuinfo/webcomponent-vl-ui-template)
+@description@
+
+## Installatie
+```
+npm install --save vl-ui-template
+```
+
+## API
+De [API](https://webcomponenten.omgeving.vlaanderen.be/doc/Vltemplate.html) bevat een overzicht van de ondersteunde attributen en een beschrijving van de beschikbare functies.
+
+## Demo
+De [demo](https://webcomponenten.omgeving.vlaanderen.be/demo/vl-template.html) pagina bevat een overzicht van de mogelijkheden met code voorbeelden. Lokaal opstarten kan met onderstaand [NPM](https://www.npmjs.com) script.
+```
+npm run demo
+```
+
+## Testen
+De webcomponent bevat verschillende unit testen die bij elke commit geautomatiseerd in Chrome en Firefox draaien. Hierdoor kunnen we bij elke release een minimum aan kwaliteit garanderen. Later zullen er ook nog UI testen toegevoegd worden zodat al de functionaliteit uitgebreid getest wordt.
+
+De testen kunnen lokaal opgestart worden met onderstaand [NPM](https://www.npmjs.com) script.
+```
+npm run test
+```
+
+## Issues
+Indien je nood hebt aan extra feature of een bug gevonden hebt, mag je hiervoor een issue aanmaken. Er zijn 3 issues templates beschikbaar:
+1. Feature request
+2. Bug
+3. Task
+
+Uiteraard is het ook toegelaten om mee te ontwikkelen door gebruik te maken van Pull Requests (PR). Gelieve volgende conventies te respecteren:
+1. Bug issue best linken aan een branch met een test die het probleem illustreert zodat de bug opgelost kan worden
+2. Elke commit die betrekking heeft tot een issue moet een verwijzing hiernaar hebben vb. #33 fix uitlijning header
+3. Elke PR moet een issue verwijzing hebben, zodat deze automatisch opgenomen kan worden in de release notes
+
+## Versionering
+We gebruiken [Semantic Versioning](https://semver.org) en voorzien elke release van release notes, zie een overzicht van de [releases](https://github.com/milieuinfo/webcomponent-vl-ui-template/releases).
+
+## Browser ondersteuning
+De webcomponenten zijn ontwikkeld door uitsluitend gebruik te maken van web standaarden (JavaScript, HTML, CSS). Hierdoor worden al de evergreen browser automatisch ondersteund.
+
+| ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png) | ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png) | ![Safari](https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png) | ![Opera](https://raw.githubusercontent.com/alrra/browser-logos/master/src/opera/opera_48x48.png) | ![Edge](https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png)
+| --- | --- | --- | --- | --- |
+| <center>Chrome</center> | <center>Firefox</center> | <center>Safari</center> | <center>Opera</center> | <center>Edge</center> |
+
+## Credits
+Zie de lijst van [ontwikkelaars](https://github.com/milieuinfo/webcomponent-vl-ui-template/graphs/contributors) die meegewerkt hebben aan de webcomponent.
+
+## Contact
+Heb je suggesties, opmerkingen of tips? Voel je dan vrij om ons te contacteren via help@omgevingvlaanderen.be.

--- a/templates/README.md.template
+++ b/templates/README.md.template
@@ -1,17 +1,17 @@
-# vl-template
-![GitHub issues](https://img.shields.io/github/issues-raw/milieuinfo/webcomponent-vl-ui-template) ![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/milieuinfo/webcomponent-vl-ui-template) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/milieuinfo/webcomponent-vl-ui-template)
+# @fullName@
+![GitHub issues](https://img.shields.io/github/issues-raw/milieuinfo/webcomponent-@fullName@) ![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/milieuinfo/webcomponent-@fullName@) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/milieuinfo/webcomponent-@fullName@)
 @description@
 
 ## Installatie
 ```
-npm install --save vl-ui-template
+npm install --save @fullName@
 ```
 
 ## API
-De [API](https://webcomponenten.omgeving.vlaanderen.be/doc/Vltemplate.html) bevat een overzicht van de ondersteunde attributen en een beschrijving van de beschikbare functies.
+De [API](https://webcomponenten.omgeving.vlaanderen.be/doc/@apiName@.html) bevat een overzicht van de ondersteunde attributen en een beschrijving van de beschikbare functies.
 
 ## Demo
-De [demo](https://webcomponenten.omgeving.vlaanderen.be/demo/vl-template.html) pagina bevat een overzicht van de mogelijkheden met code voorbeelden. Lokaal opstarten kan met onderstaand [NPM](https://www.npmjs.com) script.
+De [demo](https://webcomponenten.omgeving.vlaanderen.be/demo/@demoName@.html) pagina bevat een overzicht van de mogelijkheden met code voorbeelden. Lokaal opstarten kan met onderstaand [NPM](https://www.npmjs.com) script.
 ```
 npm run demo
 ```
@@ -36,7 +36,7 @@ Uiteraard is het ook toegelaten om mee te ontwikkelen door gebruik te maken van 
 3. Elke PR moet een issue verwijzing hebben, zodat deze automatisch opgenomen kan worden in de release notes
 
 ## Versionering
-We gebruiken [Semantic Versioning](https://semver.org) en voorzien elke release van release notes, zie een overzicht van de [releases](https://github.com/milieuinfo/webcomponent-vl-ui-template/releases).
+We gebruiken [Semantic Versioning](https://semver.org) en voorzien elke release van release notes, zie een overzicht van de [releases](https://github.com/milieuinfo/webcomponent-@fullName@/releases).
 
 ## Browser ondersteuning
 De webcomponenten zijn ontwikkeld door uitsluitend gebruik te maken van web standaarden (JavaScript, HTML, CSS). Hierdoor worden al de evergreen browser automatisch ondersteund.
@@ -46,7 +46,7 @@ De webcomponenten zijn ontwikkeld door uitsluitend gebruik te maken van web stan
 | <center>Chrome</center> | <center>Firefox</center> | <center>Safari</center> | <center>Opera</center> | <center>Edge</center> |
 
 ## Credits
-Zie de lijst van [ontwikkelaars](https://github.com/milieuinfo/webcomponent-vl-ui-template/graphs/contributors) die meegewerkt hebben aan de webcomponent.
+Zie de lijst van [ontwikkelaars](https://github.com/milieuinfo/webcomponent-@fullName@/graphs/contributors) die meegewerkt hebben aan de webcomponent.
 
 ## Contact
 Heb je suggesties, opmerkingen of tips? Voel je dan vrij om ons te contacteren via help@omgevingvlaanderen.be.


### PR DESCRIPTION
Bash script updateReadme.sh toegevoegd.
Eveneens npm run script toegevoegd dat het Bash script uitvoert.
Componenten die de Readme willen updaten kunnen dat verwezelijken door `npm explore vl-ui-util -- npm run update:readme` uit te voeren.

Zo blijft de logica geobfusceert voor de eindgebruiker.