### PR TITLE
Bevat geen testen, dus deze kunnen niet gedraaid worden

### DIFF
--- a/bamboo-specs/bamboo.yml
+++ b/bamboo-specs/bamboo.yml
@@ -27,7 +27,7 @@ Build:
     - script: |
         #!/usr/bin/env bash
         set -e
-        docker-compose -f test/docker-compose.yml up --exit-code-from tests
+        docker-compose up --exit-code-from tests
         /opt/scripts/docker/stop-docker-containers.sh
   requirements:
     - REMOTE_ONLY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3"
+services:
+  tests:
+    image: ${DOCKER_REGISTRY}node:12
+    command: bash -c "cp -R /data/. /workdir && npm install"
+    environment: 
+      - http_proxy=${http_proxy}
+      - https_proxy=${https_proxy}
+      - no_proxy=${no_proxy},selenium-hub,host
+    extra_hosts:
+      - "repository.milieuinfo.be:${REPOSITORY_FIXED_IP}"
+    working_dir: /workdir
+    volumes:
+      - ${HOME:-.}/.npmrc:/root/.npmrc:ro
+      - ${HOME:-.}/.gitconfig:/root/.gitconfig:ro
+      - ${HOME:-.}/.git-credentials:/root/.git-credentials:ro
+      - ..:/data:ro

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.6.3",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/runtime/-/runtime-7.6.3.tgz",
-      "integrity": "sha1-k1Eix0xz0iQMr9Mt21/Cps01zx8=",
+      "version": "7.7.4",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/runtime/-/runtime-7.7.4.tgz",
+      "integrity": "sha1-sjqFZ1HkvwmSYvhndniJwOP+F1s=",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -57,15 +57,15 @@
       }
     },
     "acorn": {
-      "version": "7.0.0",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-7.0.0.tgz",
-      "integrity": "sha1-JrjRzZqbcANQtxwJBVRvZNEoTno=",
+      "version": "7.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha1-lJ028sKSU12mAig1hsJHfFfrLWw=",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.2",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-      "integrity": "sha1-hLaOpEs3PE+GhgI6VR9hoht8Sk8=",
+      "version": "5.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha1-KUrbcbVzmLBoABXwo4xWPuHbU4Q=",
       "dev": true
     },
     "ajv": {
@@ -117,10 +117,13 @@
       }
     },
     "ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
-      "dev": true
+      "version": "4.3.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+      "integrity": "sha1-pM4rM9ayFLeVDYWVwhLxKsnMVp0=",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
     },
     "ansi-regex": {
       "version": "4.1.0",
@@ -354,12 +357,12 @@
       "dev": true
     },
     "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "version": "3.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-truncate": {
@@ -619,9 +622,9 @@
       "dev": true
     },
     "defer-to-connect": {
-      "version": "1.0.2",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
-      "integrity": "sha1-S651ijFLA0rjOQK1qsJajdaoYz4=",
+      "version": "1.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/defer-to-connect/-/defer-to-connect-1.1.0.tgz",
+      "integrity": "sha1-tBvX76hQjO8T+EVpdfeieMcoM/0=",
       "dev": true
     },
     "del": {
@@ -681,9 +684,9 @@
       "dev": true
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+      "version": "1.4.4",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -705,9 +708,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "6.4.0",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint/-/eslint-6.4.0.tgz",
-      "integrity": "sha1-WqkifD++khmCsu2pS6DX+uhYYRo=",
+      "version": "6.7.1",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint/-/eslint-6.7.1.tgz",
+      "integrity": "sha1-JpzMzsPvYKsyNYpE0UesIJFUuRk=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -717,19 +720,19 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.2",
+        "eslint-utils": "^1.4.3",
         "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.1",
+        "espree": "^6.1.2",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^11.7.0",
+        "globals": "^12.1.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.4.1",
+        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -738,7 +741,7 @@
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
+        "optionator": "^0.8.3",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
         "semver": "^6.1.2",
@@ -760,12 +763,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.2",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-utils/-/eslint-utils-1.4.2.tgz",
-      "integrity": "sha1-FmpRgO9qt+tGLxYv0ObyRj1zCas=",
+      "version": "1.4.3",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -775,13 +778,13 @@
       "dev": true
     },
     "espree": {
-      "version": "6.1.1",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/espree/-/espree-6.1.1.tgz",
-      "integrity": "sha1-f4Dl9yV/xH20UAItcj41ba6x5d4=",
+      "version": "6.1.2",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/espree/-/espree-6.1.2.tgz",
+      "integrity": "sha1-bCcmUJMrT5HDcU5ee19eLs9HJi0=",
       "dev": true,
       "requires": {
-        "acorn": "^7.0.0",
-        "acorn-jsx": "^5.0.2",
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.1.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
@@ -866,9 +869,9 @@
       "dev": true
     },
     "figures": {
-      "version": "2.0.0",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "version": "3.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-3.1.0.tgz",
+      "integrity": "sha1-SxmN0H2NcVMGQoZK8tRd2eRZxOw=",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -940,9 +943,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
+      "version": "7.1.6",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -972,10 +975,13 @@
       }
     },
     "globals": {
-      "version": "11.12.0",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
-      "dev": true
+      "version": "12.3.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-12.3.0.tgz",
+      "integrity": "sha1-HlZO5cTd7SqwmLD4jyRwKjxWvhM=",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
     },
     "globby": {
       "version": "6.1.0",
@@ -1038,9 +1044,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.2",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/graceful-fs/-/graceful-fs-4.2.2.tgz",
-      "integrity": "sha1-bwlSYF0BQMHP2xOO0AV3W5LWewI=",
+      "version": "4.2.3",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha1-ShL/G2A3bvCYYsIJPt2Qgyi+hCM=",
       "dev": true
     },
     "has-ansi": {
@@ -1073,9 +1079,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.4",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-      "integrity": "sha1-RBGauvS8ZGkqFqzjRwD+2cA+JUY=",
+      "version": "2.8.5",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha1-dZz88sTRVq3lmwst+r3cQqa5xww=",
       "dev": true
     },
     "http-cache-semantics": {
@@ -1100,9 +1106,9 @@
       "dev": true
     },
     "import-fresh": {
-      "version": "3.1.0",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/import-fresh/-/import-fresh-3.1.0.tgz",
-      "integrity": "sha1-bTP6Hc7235MPrgA0RvM0Fa+QURg=",
+      "version": "3.2.1",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha1-Yz/2GFBueTr1rJG/SLcmd+FcvmY=",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -1150,49 +1156,62 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.5.2",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer/-/inquirer-6.5.2.tgz",
-      "integrity": "sha1-rVCUI3XQNtMn/1KMCL1fqwiZKMo=",
+      "version": "7.0.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer/-/inquirer-7.0.0.tgz",
+      "integrity": "sha1-nisDLd532h2124BHWLj+o6lwUZo=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.2.0",
+        "ansi-escapes": "^4.2.1",
         "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
+        "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.12",
-        "mute-stream": "0.0.7",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
         "run-async": "^2.2.0",
         "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
+        "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "version": "4.2.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           },
           "dependencies": {
             "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "version": "6.0.0",
+              "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+              "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "^5.0.0"
               }
             }
           }
@@ -1474,6 +1493,12 @@
         "through": "^2.3.8"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
+          "dev": true
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -1486,6 +1511,15 @@
           "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
           "dev": true
         },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
         "external-editor": {
           "version": "2.2.0",
           "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/external-editor/-/external-editor-2.2.0.tgz",
@@ -1495,6 +1529,15 @@
             "chardet": "^0.4.0",
             "iconv-lite": "^0.4.17",
             "tmp": "^0.0.33"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "inquirer": {
@@ -1517,6 +1560,37 @@
             "string-width": "^2.1.0",
             "strip-ansi": "^4.0.0",
             "through": "^2.3.6"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "rxjs": {
@@ -1642,6 +1716,51 @@
         "cli-cursor": "^2.1.0",
         "date-fns": "^1.27.2",
         "figures": "^2.0.0"
+      },
+      "dependencies": {
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        }
       }
     },
     "load-json-file": {
@@ -1698,11 +1817,51 @@
         "wrap-ansi": "^3.0.1"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
+          "dev": true
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
         },
         "string-width": {
           "version": "2.1.1",
@@ -1811,9 +1970,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+      "version": "2.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
       "dev": true
     },
     "mimic-response": {
@@ -1863,9 +2022,9 @@
       "dev": true
     },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "version": "0.0.8",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=",
       "dev": true
     },
     "natural-compare": {
@@ -1911,9 +2070,9 @@
       }
     },
     "normalize-url": {
-      "version": "4.4.1",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-url/-/normalize-url-4.4.1.tgz",
-      "integrity": "sha1-genBU7CtV0N1VpbyqiBIjUjpYrY=",
+      "version": "4.5.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha1-RTNUCH5sqWlXvY9br3U/WYIUISk=",
       "dev": true
     },
     "np": {
@@ -1946,6 +2105,12 @@
         "update-notifier": "^2.1.0"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
+          "dev": true
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -1958,6 +2123,15 @@
           "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
           "dev": true
         },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
         "external-editor": {
           "version": "2.2.0",
           "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/external-editor/-/external-editor-2.2.0.tgz",
@@ -1967,6 +2141,15 @@
             "chardet": "^0.4.0",
             "iconv-lite": "^0.4.17",
             "tmp": "^0.0.33"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "inquirer": {
@@ -1999,6 +2182,37 @@
                 "symbol-observable": "1.0.1"
               }
             }
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "semver": {
@@ -2091,26 +2305,26 @@
       }
     },
     "onetime": {
-      "version": "2.0.1",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "version": "5.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha1-//DzyRYX/mK7UBiWNumayKbfe+U=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
       "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       }
     },
     "os-tmpdir": {
@@ -2539,9 +2753,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.12.0",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve/-/resolve-1.12.0.tgz",
-      "integrity": "sha1-P8ZEo1yEpIVUYJ/ybsUrZvpXffY=",
+      "version": "1.13.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve/-/resolve-1.13.0.tgz",
+      "integrity": "sha1-6HnrOX77QFEQVu3nMAtqwoxRKQs=",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -2563,12 +2777,12 @@
       }
     },
     "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "3.1.0",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
+        "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
     },
@@ -2886,6 +3100,14 @@
       "requires": {
         "ansi-escapes": "^3.2.0",
         "supports-hyperlinks": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
+          "dev": true
+        }
       }
     },
     "text-table": {
@@ -2995,6 +3217,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
+      "dev": true
     },
     "unique-string": {
       "version": "1.0.0",
@@ -3139,10 +3367,10 @@
         }
       }
     },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
       "dev": true
     },
     "wrap-ansi": {


### PR DESCRIPTION
vl-ui-util bevat geen testen, dus deze moeten/kunnen niet uitgevoerd worden.
Echter bevatte util nog de uniforme config via `bamboo.yml` en `docker-compose.yml` die ervoor zorgde dat er op zoek werd gegaan naar het npm run script `test:grid`.

Daarom is er een aparte docker-compose-file aangemaakt die enkel een npm install gaat doen van de util. De bamboo.yml is ook aangepast zodat het build plan correct staat. Zowel `bamboo.yml` als `./docker-compose.yml` worden niet meegekopieerd naar andere componenten, dus die hebben er geen last van.