### PR TITLE
Voeg HTTP_PROXY en HTTPS_PROXY als env variable toe omdat sommige libraries HTTP_PROXY (uppercase) verwachten ipv http_proxy (lowercase)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,9 @@ services:
     environment: 
       - http_proxy=${http_proxy}
       - https_proxy=${https_proxy}
-      - no_proxy=${no_proxy},selenium-hub,host
+      - no_proxy=${no_proxy}
+      - HTTP_PROXY=${http_proxy}
+      - HTTPS_PROXY=${https_proxy}
     extra_hosts:
       - "repository.milieuinfo.be:${REPOSITORY_FIXED_IP}"
     working_dir: /workdir

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       - http_proxy=${http_proxy}
       - https_proxy=${https_proxy}
       - no_proxy=${no_proxy},selenium-hub,host
+      - HTTP_PROXY=${http_proxy}
+      - HTTPS_PROXY=${https_proxy}
     extra_hosts:
       - "repository.milieuinfo.be:${REPOSITORY_FIXED_IP}"
     working_dir: /workdir


### PR DESCRIPTION
Voeg HTTP_PROXY en HTTPS_PROXY als env variable toe omdat sommige libraries HTTP_PROXY (uppercase) verwachten ipv http_proxy (lowercase)

