### PR TITLE
UIG-326: generiekere vl demo pagina component

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -1,6 +1,6 @@
 import '../node_modules/prismjs/prism.js';
 import '../node_modules/prismjs/plugins/line-numbers/prism-line-numbers.js';
-import {VlElement, define} from "../node_modules/vl-ui-core/vl-core.src.js";
+import {VlElement, define} from "../node_modules/vl-ui-core/vl-core.js";
 
 (() => {
   const id = 'demo-style';

--- a/demo.js
+++ b/demo.js
@@ -1,5 +1,6 @@
 import '../node_modules/prismjs/prism.js';
 import '../node_modules/prismjs/plugins/line-numbers/prism-line-numbers.js';
+import {VlElement, define} from "../node_modules/vl-ui-core/vl-core.src.js";
 
 (() => {
   const id = 'demo-style';
@@ -29,3 +30,48 @@ import '../node_modules/prismjs/plugins/line-numbers/prism-line-numbers.js';
     document.head.appendChild(meta);
   }
 })();
+
+/**
+ * VlDemoPagina
+ * @class
+ * @classdesc Demo pagina helper class. Voegt H1 header toe en een te kiezen link.
+ * Elke template onder deze demo pagina zal omgevormd worden naar een voorbeeld code en de uitgevoerde code.
+ *
+ * @property {string} data-vl-title - Attribuut wordt gebruikt als titel van de demo pagina.
+ * @property {string} data-vl-link - Attribuut wordt gebruikt als link naar webuniversum.
+ * @property {string} <template data-vl-title=...> - Attribuut wordt gebruikt als titel van het voorbeeld.
+ */
+export class VlDemoPagina extends VlElement(HTMLElement) {
+
+  connectedCallback() {
+    const title = document.createElement('H1');
+    title.innerHTML = this.getAttribute('data-vl-title');
+    this.insertBefore(title, this.firstChild);
+    const p = document.createElement('p');
+    p.innerHTML = `<a href="${this.getAttribute('data-vl-link')}">Meer voorbeelden en documentatie</a>`;
+    title.after(p);
+    this.querySelectorAll(':scope > template').forEach(VlDemoPagina._addDemo);
+  }
+
+  static _addDemo(template) {
+    const div = document.createElement('DIV');
+    div.innerHTML = `
+        <h2>${template.getAttribute('data-vl-title')}</h2>
+        <pre>
+            <code class="line-numbers language-markup">${VlDemoPagina.__encodeHTML(template.innerHTML)}</code>
+        </pre>
+        <div class="demo">
+              ${template.innerHTML}
+        </div>`;
+    template.after(div);
+    template.remove();
+  }
+
+  static __encodeHTML(str) {
+    return str.replace(/[\u00A0-\u9999<>&](?!#)/gim, function(i) {
+      return '&#' + i.charCodeAt(0) + ';';
+    });
+  }
+}
+
+define('vl-demo-pagina', VlDemoPagina);

--- a/demo.scss
+++ b/demo.scss
@@ -7,6 +7,7 @@ body {
     margin: auto !important;
     background-color: #ffffff;
 
+    > vl-demo-pagina > div:not(:first-child):not([class]),
     > div:not(:first-child):not([class]) {
         margin-top: 5rem;
     }
@@ -17,6 +18,7 @@ body {
     margin-bottom: 15px;
 }
 
+vl-demo-pagina > div > pre,
 body > div > pre {
     border: 1px dotted lightgray !important;
     white-space: pre-wrap !important;
@@ -26,14 +28,18 @@ body > div > pre {
     padding-bottom: 0px !important;
 }
 
+vl-demo-pagina > div > pre > code,
 body > div > pre > code {
     white-space: pre !important;
+    margin-left: -50px;
 }
 
+vl-demo-pagina > h1:not([is='vl-h1']),
 body > h1:not([is='vl-h1']) {
     font-size: x-large !important;
 }
 
+vl-demo-pagina > div > h2:not([is='vl-h2']),
 body > div > h2:not([is='vl-h2']) {
     font-size: large !important;
     margin-top: 20px !important;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
@@ -44,12 +44,12 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
@@ -67,7 +67,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
@@ -552,7 +552,7 @@
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.13.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
           "integrity": "sha1-fPanfY9cb2Drc8X8GVWyzrAea/U="
         }
       }
@@ -585,7 +585,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
@@ -593,7 +593,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
@@ -610,12 +610,12 @@
     },
     "@polymer/esm-amd-loader": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.4.tgz",
       "integrity": "sha1-Tnfy9ZspsB4K0CqoPTNxbN3F+fk="
     },
     "@polymer/polymer": {
       "version": "3.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/polymer/-/polymer-3.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/polymer/-/polymer-3.3.1.tgz",
       "integrity": "sha1-mtSJktKpZ3X4CwZz86YV1t+KPfw=",
       "requires": {
         "@webcomponents/shadycss": "^1.9.1"
@@ -623,12 +623,12 @@
     },
     "@polymer/sinonjs": {
       "version": "1.17.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/sinonjs/-/sinonjs-1.17.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/sinonjs/-/sinonjs-1.17.1.tgz",
       "integrity": "sha1-5H03hbfQ6MKf65f36SSw/Fl+Lps="
     },
     "@polymer/test-fixture": {
       "version": "3.0.0-pre.21",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-3.0.0-pre.21.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-3.0.0-pre.21.tgz",
       "integrity": "sha1-hRUiB8sL9XyuvBkcgLsP22lSYU4="
     },
     "@samverschueren/stream-to-observable": {
@@ -641,12 +641,12 @@
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sindresorhus/is/-/is-0.14.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o="
     },
     "@sinonjs/commons": {
       "version": "1.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sinonjs/commons/-/commons-1.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sinonjs/commons/-/commons-1.7.0.tgz",
       "integrity": "sha1-+Q/8UqLlGfAYsTtsTaA8v/NuvtY=",
       "requires": {
         "type-detect": "4.0.8"
@@ -654,7 +654,7 @@
     },
     "@sinonjs/formatio": {
       "version": "3.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sinonjs/formatio/-/formatio-3.2.2.tgz",
       "integrity": "sha1-dxxg36dep/LWjjuUx+iIp4eBNyw=",
       "requires": {
         "@sinonjs/commons": "^1",
@@ -663,7 +663,7 @@
     },
     "@sinonjs/samsam": {
       "version": "3.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sinonjs/samsam/-/samsam-3.3.3.tgz",
       "integrity": "sha1-Rmgu/Zlnslm4ETa58SD9VFhf60o=",
       "requires": {
         "@sinonjs/commons": "^1.3.0",
@@ -673,12 +673,12 @@
     },
     "@sinonjs/text-encoding": {
       "version": "0.7.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha1-jaXGUwkVZT86Hzj9XxAdjD+AecU="
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
       "integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
       "requires": {
         "defer-to-connect": "^1.0.1"
@@ -686,7 +686,7 @@
     },
     "@types/babel-generator": {
       "version": "6.25.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-generator/-/babel-generator-6.25.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/babel-generator/-/babel-generator-6.25.3.tgz",
       "integrity": "sha1-jwbKoS0FlaBThWCr53GWbXfSkoY=",
       "requires": {
         "@types/babel-types": "*"
@@ -694,7 +694,7 @@
     },
     "@types/babel-traverse": {
       "version": "6.25.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-traverse/-/babel-traverse-6.25.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/babel-traverse/-/babel-traverse-6.25.5.tgz",
       "integrity": "sha1-bSk891I+SLUk+qe4bcPEiBkUhOU=",
       "requires": {
         "@types/babel-types": "*"
@@ -702,12 +702,12 @@
     },
     "@types/babel-types": {
       "version": "6.25.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-types/-/babel-types-6.25.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/babel-types/-/babel-types-6.25.2.tgz",
       "integrity": "sha1-XFf0WXPk8TdC28UnPdhM/+c3Op4="
     },
     "@types/babylon": {
       "version": "6.16.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babylon/-/babylon-6.16.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/babylon/-/babylon-6.16.5.tgz",
       "integrity": "sha1-HFZB22nrjN83jt0ltL53VL7rSLQ=",
       "requires": {
         "@types/babel-types": "*"
@@ -715,12 +715,12 @@
     },
     "@types/bluebird": {
       "version": "3.5.29",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/bluebird/-/bluebird-3.5.29.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/bluebird/-/bluebird-3.5.29.tgz",
       "integrity": "sha1-fNkzyQLE/IMEZRehvvlziG0AvbY="
     },
     "@types/body-parser": {
       "version": "1.17.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/body-parser/-/body-parser-1.17.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/body-parser/-/body-parser-1.17.1.tgz",
       "integrity": "sha1-GPz2F2j7XDDMxQjCHW/S6LO/eJc=",
       "requires": {
         "@types/connect": "*",
@@ -729,12 +729,12 @@
     },
     "@types/chai": {
       "version": "4.2.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chai/-/chai-4.2.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/chai/-/chai-4.2.7.tgz",
       "integrity": "sha1-HIwly/bln/p9a5ZSx45UfZpBaS0="
     },
     "@types/chai-subset": {
       "version": "1.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chai-subset/-/chai-subset-1.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/chai-subset/-/chai-subset-1.3.3.tgz",
       "integrity": "sha1-l4k4FOkqvSxTTeQiyzd+DgvarJQ=",
       "requires": {
         "@types/chai": "*"
@@ -742,12 +742,12 @@
     },
     "@types/chalk": {
       "version": "0.4.31",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chalk/-/chalk-0.4.31.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/chalk/-/chalk-0.4.31.tgz",
       "integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk="
     },
     "@types/clean-css": {
       "version": "4.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/clean-css/-/clean-css-4.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/clean-css/-/clean-css-4.2.1.tgz",
       "integrity": "sha1-ywE0JB7F5u3htTRLyClmj9mHGo0=",
       "requires": {
         "@types/node": "*"
@@ -755,17 +755,17 @@
     },
     "@types/clone": {
       "version": "0.1.30",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/clone/-/clone-0.1.30.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/clone/-/clone-0.1.30.tgz",
       "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ="
     },
     "@types/color-name": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/color-name/-/color-name-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA="
     },
     "@types/compression": {
       "version": "0.0.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/compression/-/compression-0.0.33.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/compression/-/compression-0.0.33.tgz",
       "integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
       "requires": {
         "@types/express": "*"
@@ -773,7 +773,7 @@
     },
     "@types/connect": {
       "version": "3.4.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/connect/-/connect-3.4.33.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/connect/-/connect-3.4.33.tgz",
       "integrity": "sha1-MWEMkB7KVzuHE8MzCrxua59YhUY=",
       "requires": {
         "@types/node": "*"
@@ -781,22 +781,22 @@
     },
     "@types/content-type": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/content-type/-/content-type-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/content-type/-/content-type-1.1.3.tgz",
       "integrity": "sha1-Noi9d/wS+TVUju8QKk40xRKwOgc="
     },
     "@types/cssbeautify": {
       "version": "0.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
       "integrity": "sha1-jgvuj33suVIlDaDK6+BeMFkcF+8="
     },
     "@types/doctrine": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/doctrine/-/doctrine-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/doctrine/-/doctrine-0.0.1.tgz",
       "integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0="
     },
     "@types/escape-html": {
       "version": "0.0.20",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/escape-html/-/escape-html-0.0.20.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/escape-html/-/escape-html-0.0.20.tgz",
       "integrity": "sha1-yuaYcU3WHr7lqz8q65o0uhARc1o="
     },
     "@types/estree": {
@@ -806,17 +806,17 @@
     },
     "@types/events": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/events/-/events-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc="
     },
     "@types/expect": {
       "version": "1.20.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/expect/-/expect-1.20.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/expect/-/expect-1.20.4.tgz",
       "integrity": "sha1-gojlFze/fjq118d7+mlYg3RSZOU="
     },
     "@types/express": {
       "version": "4.17.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/express/-/express-4.17.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/express/-/express-4.17.2.tgz",
       "integrity": "sha1-oPt6I9iFW6wxvAHVpYyt2bIXPmw=",
       "requires": {
         "@types/body-parser": "*",
@@ -826,7 +826,7 @@
     },
     "@types/express-serve-static-core": {
       "version": "4.17.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/express-serve-static-core/-/express-serve-static-core-4.17.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/express-serve-static-core/-/express-serve-static-core-4.17.1.tgz",
       "integrity": "sha1-gr5kp3IRsgVkHgIJCW/Tr7YkgdM=",
       "requires": {
         "@types/node": "*",
@@ -835,13 +835,13 @@
     },
     "@types/freeport": {
       "version": "1.0.21",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/freeport/-/freeport-1.0.21.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/freeport/-/freeport-1.0.21.tgz",
       "integrity": "sha1-c/ZUPtZ9PKP/+XuYVZFZi3CSBm8=",
       "optional": true
     },
     "@types/glob": {
       "version": "7.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/glob/-/glob-7.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-qlmhxuP7xCHgfM0xqUTDDrpSFXU=",
       "requires": {
         "@types/events": "*",
@@ -851,7 +851,7 @@
     },
     "@types/glob-stream": {
       "version": "6.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/glob-stream/-/glob-stream-6.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/glob-stream/-/glob-stream-6.1.0.tgz",
       "integrity": "sha1-ft6KM+WRQFNPjYrfuKye37MYl7w=",
       "requires": {
         "@types/glob": "*",
@@ -860,7 +860,7 @@
     },
     "@types/gulp-if": {
       "version": "0.0.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/gulp-if/-/gulp-if-0.0.33.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/gulp-if/-/gulp-if-0.0.33.tgz",
       "integrity": "sha1-7eziK3kl2abbX5yMDXiCqndvtng=",
       "requires": {
         "@types/node": "*",
@@ -869,7 +869,7 @@
     },
     "@types/html-minifier": {
       "version": "3.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/html-minifier/-/html-minifier-3.5.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/html-minifier/-/html-minifier-3.5.3.tgz",
       "integrity": "sha1-UnaEUTjbLOvFTHieCq+HYhoh6E8=",
       "requires": {
         "@types/clean-css": "*",
@@ -879,28 +879,28 @@
     },
     "@types/is-windows": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/is-windows/-/is-windows-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/is-windows/-/is-windows-0.2.0.tgz",
       "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8="
     },
     "@types/launchpad": {
       "version": "0.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/launchpad/-/launchpad-0.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/launchpad/-/launchpad-0.6.0.tgz",
       "integrity": "sha1-NylhCbfyd/bmxf1+DAcGvJGPu1E=",
       "optional": true
     },
     "@types/mime": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mime/-/mime-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/mime/-/mime-2.0.1.tgz",
       "integrity": "sha1-3EiIQjEqfwdRSTEpBbXjwLBUx50="
     },
     "@types/minimatch": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0="
     },
     "@types/mz": {
       "version": "0.0.29",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.29.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.29.tgz",
       "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
       "requires": {
         "@types/bluebird": "*",
@@ -914,7 +914,7 @@
     },
     "@types/opn": {
       "version": "3.0.28",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/opn/-/opn-3.0.28.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/opn/-/opn-3.0.28.tgz",
       "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
       "requires": {
         "@types/node": "*"
@@ -922,7 +922,7 @@
     },
     "@types/parse5": {
       "version": "2.2.34",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/parse5/-/parse5-2.2.34.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/parse5/-/parse5-2.2.34.tgz",
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "requires": {
         "@types/node": "*"
@@ -930,12 +930,12 @@
     },
     "@types/path-is-inside": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
       "integrity": "sha1-Atb/OJddaEveyWIESUuvnynw4X8="
     },
     "@types/pem": {
       "version": "1.9.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/pem/-/pem-1.9.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/pem/-/pem-1.9.5.tgz",
       "integrity": "sha1-zVVIteCstLQaniEGfp/NjFcInJk=",
       "requires": {
         "@types/node": "*"
@@ -943,17 +943,17 @@
     },
     "@types/range-parser": {
       "version": "1.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
     },
     "@types/relateurl": {
       "version": "0.2.28",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/relateurl/-/relateurl-0.2.28.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/relateurl/-/relateurl-0.2.28.tgz",
       "integrity": "sha1-a9p9uGU/piZD9e5p6facEaOS46Y="
     },
     "@types/resolve": {
       "version": "0.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.6.tgz",
       "integrity": "sha1-C9LyNsLhzruYt5iF31ft1xqNdw4=",
       "requires": {
         "@types/node": "*"
@@ -961,7 +961,7 @@
     },
     "@types/serve-static": {
       "version": "1.13.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/serve-static/-/serve-static-1.13.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/serve-static/-/serve-static-1.13.3.tgz",
       "integrity": "sha1-634cQcRGgnJVfol+kXHe1eLe2dE=",
       "requires": {
         "@types/express-serve-static-core": "*",
@@ -970,7 +970,7 @@
     },
     "@types/spdy": {
       "version": "3.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/spdy/-/spdy-3.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/spdy/-/spdy-3.4.4.tgz",
       "integrity": "sha1-MoL9StjEYDqkn3AX3VIKCKNFsrw=",
       "requires": {
         "@types/node": "*"
@@ -978,12 +978,12 @@
     },
     "@types/ua-parser-js": {
       "version": "0.7.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
       "integrity": "sha1-SpIIlRFXThKSiny2uZoBgxrNHdc="
     },
     "@types/uglify-js": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/uglify-js/-/uglify-js-3.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/uglify-js/-/uglify-js-3.0.4.tgz",
       "integrity": "sha1-lr6uI99vVhhiqDC0KIpJ6GuqwII=",
       "requires": {
         "source-map": "^0.6.1"
@@ -991,7 +991,7 @@
     },
     "@types/uuid": {
       "version": "3.4.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/uuid/-/uuid-3.4.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/uuid/-/uuid-3.4.6.tgz",
       "integrity": "sha1-0sTEjrhadXvykn91+TmULVIeMBY=",
       "requires": {
         "@types/node": "*"
@@ -999,7 +999,7 @@
     },
     "@types/vinyl": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/vinyl/-/vinyl-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/vinyl/-/vinyl-2.0.4.tgz",
       "integrity": "sha1-mnqAccjRTTqV1B6+cTW6vkrVmVo=",
       "requires": {
         "@types/expect": "^1.20.4",
@@ -1008,7 +1008,7 @@
     },
     "@types/vinyl-fs": {
       "version": "2.4.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/vinyl-fs/-/vinyl-fs-2.4.11.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/vinyl-fs/-/vinyl-fs-2.4.11.tgz",
       "integrity": "sha1-uYEZuLsklBQer2SbCfv+sxEWEgY=",
       "requires": {
         "@types/glob-stream": "*",
@@ -1018,7 +1018,7 @@
     },
     "@types/whatwg-url": {
       "version": "6.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
       "integrity": "sha1-Hlm4xkvA299m0DfPhEnRw9UnAjc=",
       "requires": {
         "@types/node": "*"
@@ -1026,7 +1026,7 @@
     },
     "@types/which": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/which/-/which-1.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/which/-/which-1.3.2.tgz",
       "integrity": "sha1-nCRvwMk97TEchRLfKJH7QfYif98=",
       "optional": true
     },
@@ -1042,7 +1042,7 @@
     },
     "accepts": {
       "version": "1.3.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/accepts/-/accepts-1.3.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
       "requires": {
         "mime-types": "~2.1.24",
@@ -1051,17 +1051,17 @@
     },
     "accessibility-developer-tools": {
       "version": "2.12.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
       "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ="
     },
     "acorn": {
       "version": "5.7.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-5.7.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn/-/acorn-5.7.3.tgz",
       "integrity": "sha1-Z6ojG/iBKXS4UjWpZ3Hra9B+onk="
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "requires": {
         "acorn": "^3.0.4"
@@ -1069,24 +1069,24 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
         }
       }
     },
     "adm-zip": {
       "version": "0.4.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/adm-zip/-/adm-zip-0.4.11.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/adm-zip/-/adm-zip-0.4.11.tgz",
       "integrity": "sha1-KqVMhMSwGp0PuJuxGYKlHxPj1io="
     },
     "after": {
       "version": "0.8.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/after/-/after-0.8.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "agent-base": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/agent-base/-/agent-base-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/agent-base/-/agent-base-4.3.0.tgz",
       "integrity": "sha1-gWXwHENgCbzK0LHRIvBe13Dvxu4=",
       "requires": {
         "es6-promisify": "^5.0.0"
@@ -1113,17 +1113,17 @@
     },
     "ansi-colors": {
       "version": "3.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-colors/-/ansi-colors-3.2.3.tgz",
       "integrity": "sha1-V9NbhoboUeLMBMQD8cACA5dqGBM="
     },
     "ansi-escapes": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
       "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s="
     },
     "ansi-regex": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
@@ -1141,7 +1141,7 @@
     },
     "any-promise": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/any-promise/-/any-promise-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "anymatch": {
@@ -1162,12 +1162,12 @@
     },
     "append-field": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/append-field/-/append-field-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
     },
     "archiver": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/archiver/-/archiver-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/archiver/-/archiver-3.1.1.tgz",
       "integrity": "sha1-nbeBnU2vYK7BD+hrFsuSWM7WbqA=",
       "requires": {
         "archiver-utils": "^2.1.0",
@@ -1181,7 +1181,7 @@
       "dependencies": {
         "bl": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bl/-/bl-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bl/-/bl-3.0.0.tgz",
           "integrity": "sha1-NhHsAFef0YVhdUNgsh6feEUA/4g=",
           "requires": {
             "readable-stream": "^3.0.1"
@@ -1199,7 +1199,7 @@
         },
         "tar-stream": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar-stream/-/tar-stream-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tar-stream/-/tar-stream-2.1.0.tgz",
           "integrity": "sha1-0aqjZh8Fs4tazJtwIO/cpReaLMM=",
           "requires": {
             "bl": "^3.0.0",
@@ -1213,7 +1213,7 @@
     },
     "archiver-utils": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/archiver-utils/-/archiver-utils-2.1.0.tgz",
       "integrity": "sha1-6KRg6UtpPD49oYKgmMpihbqSSeI=",
       "requires": {
         "glob": "^7.1.4",
@@ -1230,14 +1230,14 @@
       "dependencies": {
         "normalize-path": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-3.0.0.tgz",
           "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
         }
       }
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -1245,22 +1245,22 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-back": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-back/-/array-back-3.1.0.tgz",
       "integrity": "sha1-uIWdelCIccmnss9C+ZQo9l6Wv7A="
     },
     "array-find-index": {
@@ -1270,12 +1270,12 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-from": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-from/-/array-from-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-from/-/array-from-2.1.1.tgz",
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
     },
     "array-union": {
@@ -1293,12 +1293,12 @@
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "arraybuffer.slice": {
       "version": "0.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
       "integrity": "sha1-O7xCdd1YTMGxCAm4nU6LY6aednU="
     },
     "arrify": {
@@ -1308,7 +1308,7 @@
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/asn1/-/asn1-0.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -1316,28 +1316,28 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assertion-error/-/assertion-error-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs="
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "astral-regex": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/astral-regex/-/astral-regex-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
       "dev": true
     },
     "async": {
       "version": "2.6.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async/-/async-2.6.3.tgz",
       "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
       "requires": {
         "lodash": "^4.17.14"
@@ -1345,22 +1345,22 @@
     },
     "async-limiter": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async-limiter/-/async-limiter-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0="
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/atob/-/atob-2.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/atob/-/atob-2.1.2.tgz",
       "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k="
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
@@ -1370,7 +1370,7 @@
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
         "chalk": "^1.1.3",
@@ -1380,17 +1380,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -1402,12 +1402,12 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-3.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-3.0.2.tgz",
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -1415,14 +1415,14 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
     "babel-generator": {
       "version": "6.26.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-generator/-/babel-generator-6.26.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
       "requires": {
         "babel-messages": "^6.23.0",
@@ -1437,54 +1437,54 @@
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "babel-helper-evaluate-path": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
       "integrity": "sha1-pi+pxOZP9+pc6pNTF07wI6kApnw="
     },
     "babel-helper-flip-expressions": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
       "integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0="
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
       "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
     },
     "babel-helper-is-void-0": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
       "integrity": "sha1-fZwBtFYee5Xb2g9u7kj1tg5nMT4="
     },
     "babel-helper-mark-eval-scopes": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
       "integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI="
     },
     "babel-helper-remove-or-void": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
       "integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA="
     },
     "babel-helper-to-multiple-sequence-expressions": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
       "integrity": "sha1-o/kk41YYgtQvz0iQeqmPeXmkWI0="
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-messages/-/babel-messages-6.23.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -1492,7 +1492,7 @@
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
       "integrity": "sha1-8A9Qe9qjw+P/bn5emNkKesq5b38=",
       "requires": {
         "object.assign": "^4.1.0"
@@ -1500,12 +1500,12 @@
     },
     "babel-plugin-minify-builtins": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz",
       "integrity": "sha1-MeuC7RoNDv3DExL5O25HQc6Cw2s="
     },
     "babel-plugin-minify-constant-folding": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz",
       "integrity": "sha1-+EvI2/alYeXjUP+VriFrCtVRW24=",
       "requires": {
         "babel-helper-evaluate-path": "^0.5.0"
@@ -1513,7 +1513,7 @@
     },
     "babel-plugin-minify-dead-code-elimination": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.1.tgz",
       "integrity": "sha1-Ggxo5EvjDeSXbKaf/FNeCL4TaD8=",
       "requires": {
         "babel-helper-evaluate-path": "^0.5.0",
@@ -1524,7 +1524,7 @@
     },
     "babel-plugin-minify-flip-comparisons": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
       "integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
       "requires": {
         "babel-helper-is-void-0": "^0.4.3"
@@ -1532,7 +1532,7 @@
     },
     "babel-plugin-minify-guarded-expressions": {
       "version": "0.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.4.tgz",
       "integrity": "sha1-gYlg9kzAiu6dbHW+xtqXTE1iETU=",
       "requires": {
         "babel-helper-evaluate-path": "^0.5.0",
@@ -1541,12 +1541,12 @@
     },
     "babel-plugin-minify-infinity": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
       "integrity": "sha1-37h2obCKBldjhO8/kuZTumB7Oco="
     },
     "babel-plugin-minify-mangle-names": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz",
       "integrity": "sha1-vN21B8kdLJnhOL1rF6GcPCceP9M=",
       "requires": {
         "babel-helper-mark-eval-scopes": "^0.4.3"
@@ -1554,17 +1554,17 @@
     },
     "babel-plugin-minify-numeric-literals": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
       "integrity": "sha1-jk/VYcefeAEob/YOjF/Z3u6TwLw="
     },
     "babel-plugin-minify-replace": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz",
       "integrity": "sha1-0+LJlGyQlsBw78lnYc4ojsXD9xw="
     },
     "babel-plugin-minify-simplify": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.1.tgz",
       "integrity": "sha1-8hYTyLla80UKLKcVAv29kXk8jWo=",
       "requires": {
         "babel-helper-evaluate-path": "^0.5.0",
@@ -1575,7 +1575,7 @@
     },
     "babel-plugin-minify-type-constructors": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
       "integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
       "requires": {
         "babel-helper-is-void-0": "^0.4.3"
@@ -1583,27 +1583,27 @@
     },
     "babel-plugin-transform-inline-consecutive-adds": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
       "integrity": "sha1-Mj1Ho+pjqDp6w8gRro5pQfrysNE="
     },
     "babel-plugin-transform-member-expression-literals": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
       "integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8="
     },
     "babel-plugin-transform-merge-sibling-variables": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
       "integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4="
     },
     "babel-plugin-transform-minify-booleans": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
       "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg="
     },
     "babel-plugin-transform-property-literals": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
       "integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
       "requires": {
         "esutils": "^2.0.2"
@@ -1611,22 +1611,22 @@
     },
     "babel-plugin-transform-regexp-constructors": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
       "integrity": "sha1-WLd3W2OvzzMyj66aX4j71PsLSWU="
     },
     "babel-plugin-transform-remove-console": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
       "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A="
     },
     "babel-plugin-transform-remove-debugger": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
       "integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI="
     },
     "babel-plugin-transform-remove-undefined": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz",
       "integrity": "sha1-gCCLMSJXZsYwyX+i0oiVIFbqIt0=",
       "requires": {
         "babel-helper-evaluate-path": "^0.5.0"
@@ -1634,17 +1634,17 @@
     },
     "babel-plugin-transform-simplify-comparison-operators": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
       "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk="
     },
     "babel-plugin-transform-undefined-to-void": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
       "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA="
     },
     "babel-preset-minify": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-preset-minify/-/babel-preset-minify-0.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-preset-minify/-/babel-preset-minify-0.5.1.tgz",
       "integrity": "sha1-JfXQvONuyBi+gDONDllBBuIeqp8=",
       "requires": {
         "babel-plugin-minify-builtins": "^0.5.0",
@@ -1674,7 +1674,7 @@
     },
     "babel-runtime": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
         "core-js": "^2.4.0",
@@ -1683,14 +1683,14 @@
       "dependencies": {
         "core-js": {
           "version": "2.6.11",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/core-js/-/core-js-2.6.11.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/core-js/-/core-js-2.6.11.tgz",
           "integrity": "sha1-OIMUafmSK97Y7iHJ3EaYXgOZMIw="
         }
       }
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
         "babel-code-frame": "^6.26.0",
@@ -1706,19 +1706,19 @@
       "dependencies": {
         "babylon": {
           "version": "6.18.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babylon/-/babylon-6.18.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babylon/-/babylon-6.18.0.tgz",
           "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
         },
         "globals": {
           "version": "9.18.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-9.18.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globals/-/globals-9.18.0.tgz",
           "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
         }
       }
     },
     "babel-types": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-types/-/babel-types-6.26.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -1729,19 +1729,19 @@
       "dependencies": {
         "to-fast-properties": {
           "version": "1.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
         }
       }
     },
     "babylon": {
       "version": "7.0.0-beta.47",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babylon/-/babylon-7.0.0-beta.47.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babylon/-/babylon-7.0.0-beta.47.tgz",
       "integrity": "sha1-bR+kTwq+xBq3x4BIHmL9mq+96oA="
     },
     "backo2": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/backo2/-/backo2-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
     "balanced-match": {
@@ -1751,7 +1751,7 @@
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base/-/base-0.11.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/base/-/base-0.11.2.tgz",
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "requires": {
         "cache-base": "^1.0.1",
@@ -1765,7 +1765,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -1773,7 +1773,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -1781,7 +1781,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -1789,7 +1789,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -1801,27 +1801,27 @@
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
       "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
     },
     "base64-js": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64-js/-/base64-js-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/base64-js/-/base64-js-1.2.0.tgz",
       "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE="
     },
     "base64id": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64id/-/base64id-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha1-J3Csa8R9MSr5eov5pjQ0LgzSXLY="
     },
     "basic-auth": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/basic-auth/-/basic-auth-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/basic-auth/-/basic-auth-1.1.0.tgz",
       "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -1829,7 +1829,7 @@
     },
     "better-assert": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/better-assert/-/better-assert-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
       "requires": {
         "callsite": "1.0.0"
@@ -1842,7 +1842,7 @@
     },
     "bl": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bl/-/bl-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bl/-/bl-2.2.0.tgz",
       "integrity": "sha1-4aV0zfUo5AUwGbuACwQcCsiNpJM=",
       "optional": true,
       "requires": {
@@ -1852,17 +1852,17 @@
     },
     "blob": {
       "version": "0.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/blob/-/blob-0.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/blob/-/blob-0.0.5.tgz",
       "integrity": "sha1-1oDu7yX4zZGtUz9bAe7UjmTK9oM="
     },
     "bluebird": {
       "version": "3.4.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bluebird/-/bluebird-3.4.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bluebird/-/bluebird-3.4.6.tgz",
       "integrity": "sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8="
     },
     "body-parser": {
       "version": "1.19.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/body-parser/-/body-parser-1.19.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
       "requires": {
         "bytes": "3.1.0",
@@ -1879,14 +1879,14 @@
       "dependencies": {
         "qs": {
           "version": "6.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
           "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw="
         }
       }
     },
     "bower-config": {
       "version": "1.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bower-config/-/bower-config-1.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bower-config/-/bower-config-1.4.1.tgz",
       "integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
       "requires": {
         "graceful-fs": "^4.1.3",
@@ -1912,7 +1912,7 @@
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         }
       }
@@ -1928,7 +1928,7 @@
     },
     "braces": {
       "version": "2.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-2.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/braces/-/braces-2.3.2.tgz",
       "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "requires": {
         "arr-flatten": "^1.1.0",
@@ -1945,7 +1945,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -1955,7 +1955,7 @@
     },
     "browser-capabilities": {
       "version": "1.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-capabilities/-/browser-capabilities-1.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browser-capabilities/-/browser-capabilities-1.1.4.tgz",
       "integrity": "sha1-pr1legehNFMq1mxyK4lJkER4uXM=",
       "requires": {
         "@types/ua-parser-js": "^0.7.31",
@@ -1964,12 +1964,12 @@
     },
     "browser-stdout": {
       "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA="
     },
     "browserstack": {
       "version": "1.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browserstack/-/browserstack-1.5.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browserstack/-/browserstack-1.5.3.tgz",
       "integrity": "sha1-k6tIeZoS75nb0HTdWVQQ3bGWp6w=",
       "optional": true,
       "requires": {
@@ -1978,7 +1978,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "optional": true,
           "requires": {
@@ -1987,7 +1987,7 @@
         },
         "https-proxy-agent": {
           "version": "2.2.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
           "integrity": "sha1-TuenN6vZJniik9mzShr00NCMeHs=",
           "optional": true,
           "requires": {
@@ -1997,7 +1997,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "optional": true
         }
@@ -2005,7 +2005,7 @@
     },
     "buffer": {
       "version": "5.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer/-/buffer-5.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/buffer/-/buffer-5.4.3.tgz",
       "integrity": "sha1-P7ycaetxPTI+P8Gole7gcQwHIRU=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -2014,22 +2014,22 @@
     },
     "buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer-from/-/buffer-from-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
     },
     "builtins": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/builtins/-/builtins-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
     },
     "busboy": {
       "version": "0.2.14",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/busboy/-/busboy-0.2.14.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/busboy/-/busboy-0.2.14.tgz",
       "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
       "requires": {
         "dicer": "0.2.5",
@@ -2038,12 +2038,12 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2054,19 +2054,19 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "bytes": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bytes/-/bytes-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY="
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cache-base/-/cache-base-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "requires": {
         "collection-visit": "^1.0.0",
@@ -2082,7 +2082,7 @@
     },
     "cacheable-request": {
       "version": "6.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cacheable-request/-/cacheable-request-6.1.0.tgz",
       "integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
       "requires": {
         "clone-response": "^1.0.2",
@@ -2096,7 +2096,7 @@
       "dependencies": {
         "get-stream": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-5.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-5.1.0.tgz",
           "integrity": "sha1-ASA83JJZf5uQkGfD5lbMH008Tck=",
           "requires": {
             "pump": "^3.0.0"
@@ -2104,25 +2104,25 @@
         },
         "lowercase-keys": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
           "integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk="
         }
       }
     },
     "callsite": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/callsite/-/callsite-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
     },
     "callsites": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/callsites/-/callsites-3.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
       "dev": true
     },
     "camel-case": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camel-case/-/camel-case-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "requires": {
         "no-case": "^2.2.0",
@@ -2131,7 +2131,7 @@
     },
     "camelcase": {
       "version": "5.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-5.3.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
     },
     "camelcase-keys": {
@@ -2146,14 +2146,14 @@
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         }
       }
     },
     "cancel-token": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cancel-token/-/cancel-token-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cancel-token/-/cancel-token-0.1.1.tgz",
       "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
       "requires": {
         "@types/node": "^4.0.30"
@@ -2161,7 +2161,7 @@
       "dependencies": {
         "@types/node": {
           "version": "4.9.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/node/-/node-4.9.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/node/-/node-4.9.4.tgz",
           "integrity": "sha1-de+Rczr6qFawHhLabs9Iqp1eIh8="
         }
       }
@@ -2173,12 +2173,12 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chai/-/chai-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chai/-/chai-4.2.0.tgz",
       "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
       "requires": {
         "assertion-error": "^1.1.0",
@@ -2191,7 +2191,7 @@
     },
     "chai-as-promised": {
       "version": "7.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
       "integrity": "sha1-CGRdgl3rhpbuYXJdv1kMAS6wDKA=",
       "requires": {
         "check-error": "^1.0.2"
@@ -2209,7 +2209,7 @@
       "dependencies": {
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "requires": {
             "has-flag": "^3.0.0"
@@ -2224,12 +2224,12 @@
     },
     "charenc": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/charenc/-/charenc-0.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "check-error": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/check-error/-/check-error-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "chokidar": {
@@ -2301,12 +2301,12 @@
     },
     "chownr": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chownr/-/chownr-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chownr/-/chownr-1.1.3.tgz",
       "integrity": "sha1-Qtg31SOWiNVfMDADpQgjD6ZycUI="
     },
     "chromedriver": {
       "version": "79.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chromedriver/-/chromedriver-79.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chromedriver/-/chromedriver-79.0.0.tgz",
       "integrity": "sha1-FmCsKZJN/NhHkRAlWT1rZ0au6jU=",
       "requires": {
         "del": "^4.1.1",
@@ -2323,7 +2323,7 @@
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/class-utils/-/class-utils-0.3.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "requires": {
         "arr-union": "^3.1.0",
@@ -2334,7 +2334,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -2344,7 +2344,7 @@
     },
     "clean-css": {
       "version": "4.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clean-css/-/clean-css-4.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clean-css/-/clean-css-4.2.1.tgz",
       "integrity": "sha1-LUEe92uFabbQyEBo2r6FsKpeXBc=",
       "requires": {
         "source-map": "~0.6.0"
@@ -2352,7 +2352,7 @@
     },
     "cleankill": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cleankill/-/cleankill-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cleankill/-/cleankill-2.0.0.tgz",
       "integrity": "sha1-WYMN/ItBHVPccq0J1Fp46jMWGpE="
     },
     "cli-boxes": {
@@ -2362,7 +2362,7 @@
     },
     "cli-cursor": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
         "restore-cursor": "^2.0.0"
@@ -2428,7 +2428,7 @@
     },
     "cliui": {
       "version": "5.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cliui/-/cliui-5.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
       "requires": {
         "string-width": "^3.1.0",
@@ -2438,12 +2438,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -2453,7 +2453,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -2463,12 +2463,12 @@
     },
     "clone": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone/-/clone-2.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "clone-response": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone-response/-/clone-response-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "requires": {
         "mimic-response": "^1.0.0"
@@ -2476,7 +2476,7 @@
     },
     "clone-stats": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone-stats/-/clone-stats-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clone-stats/-/clone-stats-0.0.1.tgz",
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
     },
     "code-point-at": {
@@ -2486,7 +2486,7 @@
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
         "map-visit": "^1.0.0",
@@ -2495,7 +2495,7 @@
     },
     "color": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color/-/color-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color/-/color-3.0.0.tgz",
       "integrity": "sha1-2SC0Mo1TSjrIKV1o971LpsQnvpo=",
       "requires": {
         "color-convert": "^1.9.1",
@@ -2517,7 +2517,7 @@
     },
     "color-string": {
       "version": "1.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-string/-/color-string-1.5.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha1-ybvF8BtYtUkvPWhXRZy2WQziBMw=",
       "requires": {
         "color-name": "^1.0.0",
@@ -2526,17 +2526,17 @@
     },
     "colornames": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colornames/-/colornames-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/colornames/-/colornames-1.1.1.tgz",
       "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
     },
     "colors": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colors/-/colors-1.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/colors/-/colors-1.4.0.tgz",
       "integrity": "sha1-xQSRR51MG9rtLJztMs98fcI2D3g="
     },
     "colorspace": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colorspace/-/colorspace-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/colorspace/-/colorspace-1.1.2.tgz",
       "integrity": "sha1-4BKJUNCCuGohaFgHlqCqXWxo2MU=",
       "requires": {
         "color": "3.0.x",
@@ -2545,7 +2545,7 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -2553,7 +2553,7 @@
     },
     "command-line-args": {
       "version": "5.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/command-line-args/-/command-line-args-5.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/command-line-args/-/command-line-args-5.1.1.tgz",
       "integrity": "sha1-iOeT5bs86zB1SoaGPwQBrJL9Npo=",
       "requires": {
         "array-back": "^3.0.1",
@@ -2564,7 +2564,7 @@
     },
     "command-line-usage": {
       "version": "5.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/command-line-usage/-/command-line-usage-5.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/command-line-usage/-/command-line-usage-5.0.5.tgz",
       "integrity": "sha1-XyWTP/5t7dmDxjXTiiHX5iP9o1c=",
       "requires": {
         "array-back": "^2.0.0",
@@ -2575,7 +2575,7 @@
       "dependencies": {
         "array-back": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
           "integrity": "sha1-aHdHHVHsycm/phNvtsfV/ml0gCI=",
           "requires": {
             "typical": "^2.6.1"
@@ -2583,7 +2583,7 @@
         },
         "typical": {
           "version": "2.6.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
           "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
         }
       }
@@ -2595,22 +2595,22 @@
     },
     "component-bind": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-bind/-/component-bind-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-bind/-/component-bind-1.0.0.tgz",
       "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A="
     },
     "component-inherit": {
       "version": "0.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-inherit/-/component-inherit-0.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
     },
     "compress-commons": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compress-commons/-/compress-commons-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/compress-commons/-/compress-commons-2.1.1.tgz",
       "integrity": "sha1-lBDZpTTPhDXj+7t8bOSN4twvBhA=",
       "requires": {
         "buffer-crc32": "^0.2.13",
@@ -2621,14 +2621,14 @@
       "dependencies": {
         "normalize-path": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-3.0.0.tgz",
           "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
         }
       }
     },
     "compressible": {
       "version": "2.0.18",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compressible/-/compressible-2.0.18.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha1-r1PMprBw1MPAdQ+9dyhqbXzEb7o=",
       "requires": {
         "mime-db": ">= 1.43.0 < 2"
@@ -2636,7 +2636,7 @@
     },
     "compression": {
       "version": "1.7.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compression/-/compression-1.7.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/compression/-/compression-1.7.4.tgz",
       "integrity": "sha1-lVI+/xcMpXwpoMpB5v4TH0Hlu48=",
       "requires": {
         "accepts": "~1.3.5",
@@ -2650,7 +2650,7 @@
       "dependencies": {
         "bytes": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bytes/-/bytes-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bytes/-/bytes-3.0.0.tgz",
           "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
         }
       }
@@ -2662,7 +2662,7 @@
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/concat-stream/-/concat-stream-1.6.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "requires": {
         "buffer-from": "^1.0.0",
@@ -2686,7 +2686,7 @@
     },
     "content-disposition": {
       "version": "0.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/content-disposition/-/content-disposition-0.5.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha1-4TDK9+cnkIfFYWwgB9BIVpiYT70=",
       "requires": {
         "safe-buffer": "5.1.2"
@@ -2694,12 +2694,12 @@
     },
     "content-type": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/content-type/-/content-type-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
     },
     "convert-source-map": {
       "version": "1.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/convert-source-map/-/convert-source-map-1.7.0.tgz",
       "integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -2707,22 +2707,22 @@
     },
     "cookie": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie/-/cookie-0.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha1-vrQ35wIrO21JAZ0IhmUwPr6cFLo="
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "copyfiles": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/copyfiles/-/copyfiles-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/copyfiles/-/copyfiles-2.1.1.tgz",
       "integrity": "sha1-1DDhIteID5LEXTciCLCvA7DDnbY=",
       "dev": true,
       "requires": {
@@ -2736,13 +2736,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -2753,7 +2753,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -2762,7 +2762,7 @@
         },
         "yargs": {
           "version": "13.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs/-/yargs-13.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs/-/yargs-13.3.0.tgz",
           "integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
           "dev": true,
           "requires": {
@@ -2787,12 +2787,12 @@
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
       "version": "2.8.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cors/-/cors-2.8.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cors/-/cors-2.8.5.tgz",
       "integrity": "sha1-6sEdpRWS3Ya58G9uesKTs9+HXSk=",
       "requires": {
         "object-assign": "^4",
@@ -2801,12 +2801,12 @@
     },
     "corser": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/corser/-/corser-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/corser/-/corser-2.0.1.tgz",
       "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c="
     },
     "crc": {
       "version": "3.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crc/-/crc-3.8.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crc/-/crc-3.8.0.tgz",
       "integrity": "sha1-rWAmnCyFb4wpnixMwN5FVpFAVsY=",
       "requires": {
         "buffer": "^5.1.0"
@@ -2814,7 +2814,7 @@
     },
     "crc32-stream": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crc32-stream/-/crc32-stream-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crc32-stream/-/crc32-stream-3.0.1.tgz",
       "integrity": "sha1-yubu7QA7DkTXOdJ53lrmOxcbToU=",
       "requires": {
         "crc": "^3.4.4",
@@ -2855,7 +2855,7 @@
     },
     "crypt": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crypt/-/crypt-0.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-random-string": {
@@ -2870,7 +2870,7 @@
     },
     "css-slam": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/css-slam/-/css-slam-2.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/css-slam/-/css-slam-2.1.2.tgz",
       "integrity": "sha1-PTWxkiyz4AAqRciasYlJJQjEk+U=",
       "requires": {
         "command-line-args": "^5.0.2",
@@ -2882,7 +2882,7 @@
     },
     "cssbeautify": {
       "version": "0.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cssbeautify/-/cssbeautify-0.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cssbeautify/-/cssbeautify-0.3.1.tgz",
       "integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c="
     },
     "currently-unhandled": {
@@ -2895,7 +2895,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -2908,7 +2908,7 @@
     },
     "debug": {
       "version": "2.6.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "requires": {
         "ms": "2.0.0"
@@ -2937,12 +2937,12 @@
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "3.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decompress-response/-/decompress-response-3.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
         "mimic-response": "^1.0.0"
@@ -2950,7 +2950,7 @@
     },
     "deep-eql": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-eql/-/deep-eql-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "requires": {
         "type-detect": "^4.0.0"
@@ -2963,17 +2963,17 @@
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "defer-to-connect": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
       "integrity": "sha1-iK5pS5P2e4GBWiyMdprvZXSsjy8="
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-properties/-/define-properties-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "requires": {
         "object-keys": "^1.0.12"
@@ -2981,7 +2981,7 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "requires": {
         "is-descriptor": "^1.0.2",
@@ -2990,7 +2990,7 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -2998,7 +2998,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -3006,7 +3006,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -3018,7 +3018,7 @@
     },
     "del": {
       "version": "4.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/del/-/del-4.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/del/-/del-4.1.1.tgz",
       "integrity": "sha1-no8RciLqRKMf86FWwEm5kFKp8LQ=",
       "requires": {
         "@types/glob": "^7.1.1",
@@ -3032,7 +3032,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegate": {
@@ -3043,22 +3043,22 @@
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-file": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-file/-/detect-file-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
     },
     "detect-indent": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-indent/-/detect-indent-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
         "repeating": "^2.0.0"
@@ -3066,12 +3066,12 @@
     },
     "detect-node": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-node/-/detect-node-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw="
     },
     "diagnostics": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diagnostics/-/diagnostics-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/diagnostics/-/diagnostics-1.1.1.tgz",
       "integrity": "sha1-yrasM99wydmnJ0kK5DrJladpsio=",
       "requires": {
         "colorspace": "1.1.x",
@@ -3081,7 +3081,7 @@
     },
     "dicer": {
       "version": "0.2.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dicer/-/dicer-0.2.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dicer/-/dicer-0.2.5.tgz",
       "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
       "requires": {
         "readable-stream": "1.1.x",
@@ -3090,12 +3090,12 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3106,19 +3106,19 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "diff": {
       "version": "3.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diff/-/diff-3.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/diff/-/diff-3.5.0.tgz",
       "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI="
     },
     "doctrine": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/doctrine/-/doctrine-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
       "requires": {
         "esutils": "^2.0.2"
@@ -3126,7 +3126,7 @@
     },
     "dom-urls": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dom-urls/-/dom-urls-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dom-urls/-/dom-urls-1.1.0.tgz",
       "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
       "requires": {
         "urijs": "^1.16.1"
@@ -3134,7 +3134,7 @@
     },
     "dom5": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dom5/-/dom5-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dom5/-/dom5-3.0.1.tgz",
       "integrity": "sha1-zfxzMfN24oS/N55uoFSvwTZwKUQ=",
       "requires": {
         "@types/parse5": "^2.2.34",
@@ -3157,7 +3157,7 @@
     },
     "duplexer2": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexer2/-/duplexer2-0.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "requires": {
         "readable-stream": "^2.0.2"
@@ -3170,7 +3170,7 @@
     },
     "duplexify": {
       "version": "3.7.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexify/-/duplexify-3.7.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
       "requires": {
         "end-of-stream": "^1.0.0",
@@ -3181,7 +3181,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
         "jsbn": "~0.1.0",
@@ -3190,7 +3190,7 @@
     },
     "ecstatic": {
       "version": "3.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ecstatic/-/ecstatic-3.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ecstatic/-/ecstatic-3.3.2.tgz",
       "integrity": "sha1-bR3UmBTQBZRoLGUq22YHamnUbEg=",
       "requires": {
         "he": "^1.1.1",
@@ -3201,14 +3201,14 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elegant-spinner": {
@@ -3218,17 +3218,17 @@
     },
     "emitter-component": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emitter-component/-/emitter-component-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emitter-component/-/emitter-component-1.1.1.tgz",
       "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
     },
     "emoji-regex": {
       "version": "7.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY="
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "requires": {
         "env-variable": "0.0.x"
@@ -3236,12 +3236,12 @@
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "1.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
       "requires": {
         "once": "^1.4.0"
@@ -3249,7 +3249,7 @@
     },
     "engine.io": {
       "version": "3.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io/-/engine.io-3.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/engine.io/-/engine.io-3.4.0.tgz",
       "integrity": "sha1-OpYsxFNZKMJSdZoA+YUZy0bFP/M=",
       "requires": {
         "accepts": "~1.3.4",
@@ -3262,12 +3262,12 @@
       "dependencies": {
         "cookie": {
           "version": "0.3.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie/-/cookie-0.3.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cookie/-/cookie-0.3.1.tgz",
           "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
@@ -3275,14 +3275,14 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "engine.io-client": {
       "version": "3.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io-client/-/engine.io-client-3.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/engine.io-client/-/engine.io-client-3.4.0.tgz",
       "integrity": "sha1-gqZCtChiqbP3oYj0F3ay3qtkNwA=",
       "requires": {
         "component-emitter": "1.2.1",
@@ -3300,12 +3300,12 @@
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
@@ -3313,12 +3313,12 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         },
         "ws": {
           "version": "6.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ws/-/ws-6.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ws/-/ws-6.1.4.tgz",
           "integrity": "sha1-W1yIAK+rkl6UzLKdFTyNAsF3bvk=",
           "requires": {
             "async-limiter": "~1.0.0"
@@ -3328,7 +3328,7 @@
     },
     "engine.io-parser": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
       "integrity": "sha1-MSxIlPV9UqArQgho2ntcHISvgO0=",
       "requires": {
         "after": "0.8.2",
@@ -3340,7 +3340,7 @@
     },
     "env-variable": {
       "version": "0.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/env-variable/-/env-variable-0.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/env-variable/-/env-variable-0.0.5.tgz",
       "integrity": "sha1-kT3YML7xHpagOcA41BMGBOujf4g="
     },
     "error-ex": {
@@ -3371,7 +3371,7 @@
     },
     "es-to-primitive": {
       "version": "1.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
       "requires": {
         "is-callable": "^1.1.4",
@@ -3381,12 +3381,12 @@
     },
     "es6-promise": {
       "version": "4.2.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promise/-/es6-promise-4.2.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es6-promise/-/es6-promise-4.2.8.tgz",
       "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo="
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -3394,7 +3394,7 @@
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
@@ -3404,7 +3404,7 @@
     },
     "eslint": {
       "version": "6.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint/-/eslint-6.8.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha1-YiYtZylzn5J1cjgkMC+yJ8jJP/s=",
       "dev": true,
       "requires": {
@@ -3449,19 +3449,19 @@
       "dependencies": {
         "acorn": {
           "version": "7.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-7.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn/-/acorn-7.1.0.tgz",
           "integrity": "sha1-lJ028sKSU12mAig1hsJHfFfrLWw=",
           "dev": true
         },
         "acorn-jsx": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
           "integrity": "sha1-KUrbcbVzmLBoABXwo4xWPuHbU4Q=",
           "dev": true
         },
         "ansi-escapes": {
           "version": "4.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
           "integrity": "sha1-pM4rM9ayFLeVDYWVwhLxKsnMVp0=",
           "dev": true,
           "requires": {
@@ -3470,13 +3470,13 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
           "dev": true
         },
         "cli-cursor": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
           "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
           "dev": true,
           "requires": {
@@ -3485,7 +3485,7 @@
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -3494,7 +3494,7 @@
         },
         "doctrine": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/doctrine/-/doctrine-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/doctrine/-/doctrine-3.0.0.tgz",
           "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
           "dev": true,
           "requires": {
@@ -3503,13 +3503,13 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
           "dev": true
         },
         "espree": {
           "version": "6.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/espree/-/espree-6.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/espree/-/espree-6.1.2.tgz",
           "integrity": "sha1-bCcmUJMrT5HDcU5ee19eLs9HJi0=",
           "dev": true,
           "requires": {
@@ -3520,7 +3520,7 @@
         },
         "figures": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/figures/-/figures-3.1.0.tgz",
           "integrity": "sha1-SxmN0H2NcVMGQoZK8tRd2eRZxOw=",
           "dev": true,
           "requires": {
@@ -3529,7 +3529,7 @@
         },
         "glob-parent": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-5.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-5.1.0.tgz",
           "integrity": "sha1-X0wdHnSNMM1zrSlEs1d6gbCB6MI=",
           "dev": true,
           "requires": {
@@ -3538,7 +3538,7 @@
         },
         "globals": {
           "version": "12.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-12.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globals/-/globals-12.3.0.tgz",
           "integrity": "sha1-HlZO5cTd7SqwmLD4jyRwKjxWvhM=",
           "dev": true,
           "requires": {
@@ -3547,7 +3547,7 @@
         },
         "inquirer": {
           "version": "7.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer/-/inquirer-7.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inquirer/-/inquirer-7.0.3.tgz",
           "integrity": "sha1-+bTNLf9Yufc+jUN1lDas4VvtRWc=",
           "dev": true,
           "requires": {
@@ -3568,13 +3568,13 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
           "dev": true
         },
         "is-glob": {
           "version": "4.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-4.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-4.0.1.tgz",
           "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
           "dev": true,
           "requires": {
@@ -3583,25 +3583,25 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
           "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
           "dev": true
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         },
         "mute-stream": {
           "version": "0.0.8",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.8.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.8.tgz",
           "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=",
           "dev": true
         },
         "onetime": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-5.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/onetime/-/onetime-5.1.0.tgz",
           "integrity": "sha1-//DzyRYX/mK7UBiWNumayKbfe+U=",
           "dev": true,
           "requires": {
@@ -3610,7 +3610,7 @@
         },
         "restore-cursor": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-3.1.0.tgz",
           "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
           "dev": true,
           "requires": {
@@ -3620,13 +3620,13 @@
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "dev": true,
           "requires": {
@@ -3637,7 +3637,7 @@
           "dependencies": {
             "strip-ansi": {
               "version": "6.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
               "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
               "dev": true,
               "requires": {
@@ -3648,7 +3648,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -3657,7 +3657,7 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
               "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
               "dev": true
             }
@@ -3665,7 +3665,7 @@
         },
         "strip-json-comments": {
           "version": "3.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
           "integrity": "sha1-hXE5dakfuHvxswXMp3OV5A0qZKc=",
           "dev": true
         }
@@ -3683,7 +3683,7 @@
     },
     "eslint-utils": {
       "version": "1.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-utils/-/eslint-utils-1.4.3.tgz",
       "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
       "dev": true,
       "requires": {
@@ -3698,7 +3698,7 @@
     },
     "espree": {
       "version": "3.5.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/espree/-/espree-3.5.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/espree/-/espree-3.5.4.tgz",
       "integrity": "sha1-sPRHGHyKi+2US4FaZgvd9d610ac=",
       "requires": {
         "acorn": "^5.5.0",
@@ -3707,12 +3707,12 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esprima/-/esprima-4.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
     },
     "esquery": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esquery/-/esquery-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esquery/-/esquery-1.0.1.tgz",
       "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
       "dev": true,
       "requires": {
@@ -3721,7 +3721,7 @@
     },
     "esrecurse": {
       "version": "4.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esrecurse/-/esrecurse-4.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "dev": true,
       "requires": {
@@ -3741,7 +3741,7 @@
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "event-stream": {
@@ -3760,12 +3760,12 @@
     },
     "eventemitter3": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eventemitter3/-/eventemitter3-4.0.0.tgz",
       "integrity": "sha1-1lF2FjiH7lnzhtZMgmELaWpKdOs="
     },
     "execa": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/execa/-/execa-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/execa/-/execa-1.0.0.tgz",
       "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
       "requires": {
         "cross-spawn": "^6.0.0",
@@ -3779,7 +3779,7 @@
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
         "debug": "^2.3.3",
@@ -3793,7 +3793,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -3801,7 +3801,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -3811,7 +3811,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
         "fill-range": "^2.1.0"
@@ -3819,7 +3819,7 @@
       "dependencies": {
         "fill-range": {
           "version": "2.2.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fill-range/-/fill-range-2.2.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fill-range/-/fill-range-2.2.4.tgz",
           "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
           "requires": {
             "is-number": "^2.1.0",
@@ -3831,12 +3831,12 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         },
         "is-number": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-number/-/is-number-2.1.0.tgz",
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "requires": {
             "kind-of": "^3.0.2"
@@ -3844,7 +3844,7 @@
         },
         "isobject": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "requires": {
             "isarray": "1.0.0"
@@ -3852,7 +3852,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -3862,7 +3862,7 @@
     },
     "expand-tilde": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "requires": {
         "homedir-polyfill": "^1.0.1"
@@ -3870,7 +3870,7 @@
     },
     "express": {
       "version": "4.17.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/express/-/express-4.17.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/express/-/express-4.17.1.tgz",
       "integrity": "sha1-RJH8OGBc9R+GKdOcK10Cb5ikwTQ=",
       "requires": {
         "accepts": "~1.3.7",
@@ -3907,22 +3907,22 @@
       "dependencies": {
         "ms": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
           "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
         },
         "path-to-regexp": {
           "version": "0.1.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
         },
         "qs": {
           "version": "6.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
           "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw="
         },
         "send": {
           "version": "0.17.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
           "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
           "requires": {
             "debug": "2.6.9",
@@ -3944,12 +3944,12 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
         "assign-symbols": "^1.0.0",
@@ -3958,7 +3958,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -3978,7 +3978,7 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "requires": {
         "array-unique": "^0.3.2",
@@ -3993,7 +3993,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -4001,7 +4001,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -4009,7 +4009,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -4017,7 +4017,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -4025,7 +4025,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -4037,7 +4037,7 @@
     },
     "extract-zip": {
       "version": "1.6.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extract-zip/-/extract-zip-1.6.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extract-zip/-/extract-zip-1.6.7.tgz",
       "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
       "requires": {
         "concat-stream": "1.6.2",
@@ -4048,7 +4048,7 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
@@ -4058,23 +4058,23 @@
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fast-safe-stringify": {
       "version": "2.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha1-EkqohYmSYfaK7bQqfAgN6dpgh0M="
     },
     "fd-slicer": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "requires": {
         "pend": "~1.2.0"
@@ -4082,12 +4082,12 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha1-lI50FX3xoy/RsSw6PDzctuydls0="
     },
     "fetch-mock": {
       "version": "8.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fetch-mock/-/fetch-mock-8.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fetch-mock/-/fetch-mock-8.3.1.tgz",
       "integrity": "sha1-nHmqsi+hdS/gC0h+Kycez8EThGE=",
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -4101,7 +4101,7 @@
     },
     "figures": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -4109,7 +4109,7 @@
     },
     "file-entry-cache": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
       "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
       "dev": true,
       "requires": {
@@ -4118,12 +4118,12 @@
     },
     "filename-regex": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/filename-regex/-/filename-regex-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fill-range": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fill-range/-/fill-range-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -4134,7 +4134,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -4144,7 +4144,7 @@
     },
     "finalhandler": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/finalhandler/-/finalhandler-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
       "requires": {
         "debug": "2.6.9",
@@ -4158,7 +4158,7 @@
     },
     "find-port": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-port/-/find-port-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-port/-/find-port-1.0.1.tgz",
       "integrity": "sha1-2whKbL+ZVk2Zhprnn73s9m6KGFw=",
       "requires": {
         "async": "~0.2.9"
@@ -4166,14 +4166,14 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-0.2.10.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         }
       }
     },
     "find-replace": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-replace/-/find-replace-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-replace/-/find-replace-3.0.0.tgz",
       "integrity": "sha1-Pn4j07BRZ6dvdwyfvVJYsN72jDg=",
       "requires": {
         "array-back": "^3.0.1"
@@ -4181,7 +4181,7 @@
     },
     "find-up": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "requires": {
         "locate-path": "^3.0.0"
@@ -4189,7 +4189,7 @@
     },
     "findup-sync": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/findup-sync/-/findup-sync-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/findup-sync/-/findup-sync-2.0.0.tgz",
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "requires": {
         "detect-file": "^1.0.0",
@@ -4200,12 +4200,12 @@
     },
     "first-chunk-stream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
       "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
     },
     "flat": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/flat/-/flat-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/flat/-/flat-4.1.0.tgz",
       "integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
       "requires": {
         "is-buffer": "~2.0.3"
@@ -4213,7 +4213,7 @@
     },
     "flat-cache": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/flat-cache/-/flat-cache-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/flat-cache/-/flat-cache-2.0.1.tgz",
       "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
       "dev": true,
       "requires": {
@@ -4224,7 +4224,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.6.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
           "dev": true,
           "requires": {
@@ -4235,13 +4235,13 @@
     },
     "flatted": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/flatted/-/flatted-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha1-aeV8qo8OrLwoHS4stFjUb9tEngg=",
       "dev": true
     },
     "follow-redirects": {
       "version": "1.9.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/follow-redirects/-/follow-redirects-1.9.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/follow-redirects/-/follow-redirects-1.9.0.tgz",
       "integrity": "sha1-jVvNxltxCP4VCGScecEtcy3O208=",
       "requires": {
         "debug": "^3.0.0"
@@ -4249,7 +4249,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "requires": {
             "ms": "^2.1.1"
@@ -4257,19 +4257,19 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
       "version": "0.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/for-own/-/for-own-0.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
         "for-in": "^1.0.1"
@@ -4277,17 +4277,17 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "fork-stream": {
       "version": "0.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fork-stream/-/fork-stream-0.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fork-stream/-/fork-stream-0.0.4.tgz",
       "integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA="
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/form-data/-/form-data-2.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "requires": {
         "asynckit": "^0.4.0",
@@ -4297,7 +4297,7 @@
     },
     "formatio": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/formatio/-/formatio-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "requires": {
         "samsam": "~1.1"
@@ -4305,12 +4305,12 @@
     },
     "forwarded": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/forwarded/-/forwarded-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
         "map-cache": "^0.2.2"
@@ -4318,13 +4318,13 @@
     },
     "freeport": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/freeport/-/freeport-1.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/freeport/-/freeport-1.0.5.tgz",
       "integrity": "sha1-JV6KuEFwwzuoXZkOghrl9KGpvF0=",
       "optional": true
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "from": {
@@ -4334,12 +4334,12 @@
     },
     "fs-constants": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fs-constants/-/fs-constants-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0="
     },
     "fs-minipass": {
       "version": "1.2.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fs-minipass/-/fs-minipass-1.2.7.tgz",
       "integrity": "sha1-zP+FcIQef+QmVpPaiJNsVa7X98c=",
       "requires": {
         "minipass": "^2.6.0"
@@ -4358,18 +4358,18 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/function-bind/-/function-bind-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "geckodriver": {
       "version": "1.19.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/geckodriver/-/geckodriver-1.19.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/geckodriver/-/geckodriver-1.19.1.tgz",
       "integrity": "sha1-VW+V/WRRtVPOyJ+B+Bq7784Q1uU=",
       "requires": {
         "adm-zip": "0.4.11",
@@ -4386,22 +4386,22 @@
     },
     "get-caller-file": {
       "version": "2.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
     },
     "get-func-name": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-func-name/-/get-func-name-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
     "get-stdin": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stdin/-/get-stdin-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "get-stream": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
       "requires": {
         "pump": "^3.0.0"
@@ -4409,12 +4409,12 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -4427,7 +4427,7 @@
     },
     "glob": {
       "version": "7.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.6.tgz",
       "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -4440,7 +4440,7 @@
     },
     "glob-base": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-base/-/glob-base-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
         "glob-parent": "^2.0.0",
@@ -4449,12 +4449,12 @@
       "dependencies": {
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
             "is-extglob": "^1.0.0"
@@ -4464,7 +4464,7 @@
     },
     "glob-parent": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
         "is-glob": "^2.0.0"
@@ -4472,12 +4472,12 @@
       "dependencies": {
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
             "is-extglob": "^1.0.0"
@@ -4487,7 +4487,7 @@
     },
     "glob-stream": {
       "version": "5.3.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-stream/-/glob-stream-5.3.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-stream/-/glob-stream-5.3.5.tgz",
       "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
       "requires": {
         "extend": "^3.0.0",
@@ -4502,7 +4502,7 @@
       "dependencies": {
         "arr-diff": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "requires": {
             "arr-flatten": "^1.0.1"
@@ -4510,12 +4510,12 @@
         },
         "array-unique": {
           "version": "0.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
         },
         "braces": {
           "version": "1.8.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "requires": {
             "expand-range": "^1.8.1",
@@ -4525,7 +4525,7 @@
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "requires": {
             "is-posix-bracket": "^0.1.0"
@@ -4533,7 +4533,7 @@
         },
         "extglob": {
           "version": "0.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "requires": {
             "is-extglob": "^1.0.0"
@@ -4541,7 +4541,7 @@
         },
         "glob": {
           "version": "5.0.15",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-5.0.15.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
             "inflight": "^1.0.4",
@@ -4553,7 +4553,7 @@
         },
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
             "is-glob": "^3.1.0",
@@ -4562,22 +4562,22 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         },
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "isarray": {
           "version": "0.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -4585,7 +4585,7 @@
         },
         "micromatch": {
           "version": "2.3.11",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "requires": {
             "arr-diff": "^2.0.0",
@@ -4605,7 +4605,7 @@
           "dependencies": {
             "is-glob": {
               "version": "2.0.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "requires": {
                 "is-extglob": "^1.0.0"
@@ -4615,7 +4615,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -4626,12 +4626,12 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "through2": {
           "version": "0.6.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
             "readable-stream": ">=1.0.33-1 <1.1.0-0",
@@ -4642,7 +4642,7 @@
     },
     "glob-to-regexp": {
       "version": "0.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha1-x1KXCHyFG5pXi9IX3VmpL1n+VG4="
     },
     "global-dirs": {
@@ -4655,7 +4655,7 @@
     },
     "global-modules": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-modules/-/global-modules-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
       "requires": {
         "global-prefix": "^1.0.1",
@@ -4665,7 +4665,7 @@
     },
     "global-prefix": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-prefix/-/global-prefix-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "requires": {
         "expand-tilde": "^2.0.2",
@@ -4677,7 +4677,7 @@
     },
     "globals": {
       "version": "11.12.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-11.12.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globals/-/globals-11.12.0.tgz",
       "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4="
     },
     "globby": {
@@ -4710,7 +4710,7 @@
     },
     "got": {
       "version": "5.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-5.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/got/-/got-5.6.0.tgz",
       "integrity": "sha1-ux1+4WO3gIK7yOuDbz85UATqb78=",
       "requires": {
         "create-error-class": "^3.0.1",
@@ -4733,22 +4733,22 @@
     },
     "graceful-fs": {
       "version": "4.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha1-ShL/G2A3bvCYYsIJPt2Qgyi+hCM="
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "growl": {
       "version": "1.10.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/growl/-/growl-1.10.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/growl/-/growl-1.10.5.tgz",
       "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4="
     },
     "gulp-if": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-if/-/gulp-if-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/gulp-if/-/gulp-if-2.0.2.tgz",
       "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
       "requires": {
         "gulp-match": "^1.0.3",
@@ -4758,7 +4758,7 @@
     },
     "gulp-match": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-match/-/gulp-match-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/gulp-match/-/gulp-match-1.1.0.tgz",
       "integrity": "sha1-VStwgPwAbudSyQVj+f7J1hqv308=",
       "requires": {
         "minimatch": "^3.0.3"
@@ -4766,7 +4766,7 @@
     },
     "gulp-sourcemaps": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "requires": {
         "convert-source-map": "^1.1.1",
@@ -4778,7 +4778,7 @@
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
             "is-utf8": "^0.2.0"
@@ -4788,17 +4788,17 @@
     },
     "handle-thing": {
       "version": "1.2.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/handle-thing/-/handle-thing-1.2.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/har-validator/-/har-validator-5.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
       "requires": {
         "ajv": "^6.5.5",
@@ -4807,7 +4807,7 @@
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has/-/has-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "requires": {
         "function-bind": "^1.1.1"
@@ -4830,7 +4830,7 @@
     },
     "has-binary2": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-binary2/-/has-binary2-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-binary2/-/has-binary2-1.0.3.tgz",
       "integrity": "sha1-d3asYn8+p3JQz8My2rfd9eT10R0=",
       "requires": {
         "isarray": "2.0.1"
@@ -4838,19 +4838,19 @@
       "dependencies": {
         "isarray": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
         }
       }
     },
     "has-color": {
       "version": "0.1.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-color/-/has-color-0.1.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-color/-/has-color-0.1.7.tgz",
       "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
     },
     "has-cors": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-cors/-/has-cors-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
     },
     "has-flag": {
@@ -4860,12 +4860,12 @@
     },
     "has-symbols": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-symbols/-/has-symbols-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg="
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
         "get-value": "^2.0.6",
@@ -4875,7 +4875,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
         "is-number": "^3.0.0",
@@ -4884,12 +4884,12 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         },
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -4904,12 +4904,12 @@
     },
     "he": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/he/-/he-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/he/-/he-1.2.0.tgz",
       "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8="
     },
     "homedir-polyfill": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
       "integrity": "sha1-dDKYzvTlrz4ZQWH7rcwhUdOgWOg=",
       "requires": {
         "parse-passwd": "^1.0.0"
@@ -4917,12 +4917,12 @@
     },
     "hosted-git-info": {
       "version": "2.8.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
       "integrity": "sha1-dZz88sTRVq3lmwst+r3cQqa5xww="
     },
     "hpack.js": {
       "version": "2.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hpack.js/-/hpack.js-2.1.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "requires": {
         "inherits": "^2.0.1",
@@ -4947,17 +4947,17 @@
     },
     "http-cache-semantics": {
       "version": "4.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
       "integrity": "sha1-SVcEdzJ37u9uQ/mrLCx9JZ3aJcU="
     },
     "http-deceiver": {
       "version": "1.2.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-deceiver/-/http-deceiver-1.2.7.tgz",
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "http-errors": {
       "version": "1.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.7.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
       "requires": {
         "depd": "~1.1.2",
@@ -4969,14 +4969,14 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
     "http-proxy": {
       "version": "1.18.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-proxy/-/http-proxy-1.18.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-proxy/-/http-proxy-1.18.0.tgz",
       "integrity": "sha1-2+VfY+daNH2389mZdPJpKjFKajo=",
       "requires": {
         "eventemitter3": "^4.0.0",
@@ -4986,7 +4986,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.17.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "requires": {
         "http-proxy": "^1.16.2",
@@ -4997,7 +4997,7 @@
       "dependencies": {
         "arr-diff": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "requires": {
             "arr-flatten": "^1.0.1"
@@ -5005,12 +5005,12 @@
         },
         "array-unique": {
           "version": "0.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
         },
         "braces": {
           "version": "1.8.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "requires": {
             "expand-range": "^1.8.1",
@@ -5020,7 +5020,7 @@
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "requires": {
             "is-posix-bracket": "^0.1.0"
@@ -5028,7 +5028,7 @@
         },
         "extglob": {
           "version": "0.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "requires": {
             "is-extglob": "^1.0.0"
@@ -5036,17 +5036,17 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         },
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -5054,7 +5054,7 @@
         },
         "micromatch": {
           "version": "2.3.11",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "requires": {
             "arr-diff": "^2.0.0",
@@ -5074,7 +5074,7 @@
           "dependencies": {
             "is-glob": {
               "version": "2.0.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "requires": {
                 "is-extglob": "^1.0.0"
@@ -5086,7 +5086,7 @@
     },
     "http-server": {
       "version": "0.12.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-server/-/http-server-0.12.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-server/-/http-server-0.12.0.tgz",
       "integrity": "sha1-MWtFBgPARU1KRi2XoxMoCKmFhWM=",
       "requires": {
         "basic-auth": "^1.0.3",
@@ -5103,7 +5103,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -5113,7 +5113,7 @@
     },
     "https-proxy-agent": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz",
       "integrity": "sha1-AQbvpdY9bW86uHyZn6SHej/R/5c=",
       "requires": {
         "agent-base": "^4.3.0",
@@ -5122,7 +5122,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "requires": {
             "ms": "^2.1.1"
@@ -5130,7 +5130,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
@@ -5145,23 +5145,23 @@
     },
     "ieee754": {
       "version": "1.1.13",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ieee754/-/ieee754-1.1.13.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q="
     },
     "ignore": {
       "version": "4.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ignore/-/ignore-4.0.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
       "dev": true
     },
     "immediate": {
       "version": "3.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/immediate/-/immediate-3.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "import-fresh": {
       "version": "3.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/import-fresh/-/import-fresh-3.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/import-fresh/-/import-fresh-3.2.1.tgz",
       "integrity": "sha1-Yz/2GFBueTr1rJG/SLcmd+FcvmY=",
       "dev": true,
       "requires": {
@@ -5181,7 +5181,7 @@
     },
     "indent": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent/-/indent-0.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/indent/-/indent-0.0.2.tgz",
       "integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk="
     },
     "indent-string": {
@@ -5191,7 +5191,7 @@
     },
     "indexof": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indexof/-/indexof-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "inflight": {
@@ -5205,7 +5205,7 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
     },
     "ini": {
@@ -5215,7 +5215,7 @@
     },
     "inquirer": {
       "version": "6.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer/-/inquirer-6.5.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inquirer/-/inquirer-6.5.2.tgz",
       "integrity": "sha1-rVCUI3XQNtMn/1KMCL1fqwiZKMo=",
       "requires": {
         "ansi-escapes": "^3.2.0",
@@ -5235,12 +5235,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -5250,7 +5250,7 @@
     },
     "invariant": {
       "version": "2.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/invariant/-/invariant-2.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "requires": {
         "loose-envify": "^1.0.0"
@@ -5258,22 +5258,22 @@
     },
     "invert-kv": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/invert-kv/-/invert-kv-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/invert-kv/-/invert-kv-2.0.0.tgz",
       "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI="
     },
     "ip-regex": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ip-regex/-/ip-regex-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
     "ipaddr.js": {
       "version": "1.9.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha1-N9905DCg5HVQ/lSi3v4w2KzZX2U="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -5281,12 +5281,12 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -5296,7 +5296,7 @@
     },
     "is-arguments": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arguments/-/is-arguments-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-arguments/-/is-arguments-1.0.4.tgz",
       "integrity": "sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM="
     },
     "is-arrayish": {
@@ -5314,12 +5314,12 @@
     },
     "is-buffer": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-2.0.4.tgz",
       "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM="
     },
     "is-callable": {
       "version": "1.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-callable/-/is-callable-1.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-callable/-/is-callable-1.1.5.tgz",
       "integrity": "sha1-9+RrWWiQRW23Tn9ul2yzJz0G+qs="
     },
     "is-ci": {
@@ -5332,7 +5332,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -5340,12 +5340,12 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -5355,12 +5355,12 @@
     },
     "is-date-object": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-date-object/-/is-date-object-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4="
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
@@ -5370,19 +5370,19 @@
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-5.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
         }
       }
     },
     "is-dotfile": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
         "is-primitive": "^2.0.0"
@@ -5390,17 +5390,17 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-finite/-/is-finite-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
         "number-is-nan": "^1.0.0"
@@ -5413,12 +5413,12 @@
     },
     "is-generator-function": {
       "version": "1.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-generator-function/-/is-generator-function-1.0.7.tgz",
       "integrity": "sha1-0hMuUpuwAAp/gHlNS99c1eWBNSI="
     },
     "is-glob": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "requires": {
         "is-extglob": "^2.1.0"
@@ -5435,7 +5435,7 @@
       "dependencies": {
         "is-path-inside": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
           "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "requires": {
             "path-is-inside": "^1.0.1"
@@ -5450,7 +5450,7 @@
     },
     "is-number": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -5458,12 +5458,12 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -5486,12 +5486,12 @@
     },
     "is-path-cwd": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
       "integrity": "sha1-Z9Q7gmZKe1GR/ZEZEn6zAASKn9s="
     },
     "is-path-in-cwd": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
       "integrity": "sha1-v+Lcomxp85cmWkAJljYCk1oFOss=",
       "requires": {
         "is-path-inside": "^2.1.0"
@@ -5499,7 +5499,7 @@
     },
     "is-path-inside": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-2.1.0.tgz",
       "integrity": "sha1-fJgQWH1lmkDSe8201WFuqwWUlLI=",
       "requires": {
         "path-is-inside": "^1.0.2"
@@ -5512,7 +5512,7 @@
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "requires": {
         "isobject": "^3.0.1"
@@ -5520,12 +5520,12 @@
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
     },
     "is-primitive": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-primitive/-/is-primitive-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
     "is-promise": {
@@ -5540,7 +5540,7 @@
     },
     "is-regex": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-regex/-/is-regex-1.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-regex/-/is-regex-1.0.5.tgz",
       "integrity": "sha1-OdWJo1i/GJZ/cmlnEguPwa7XTq4=",
       "requires": {
         "has": "^1.0.3"
@@ -5548,12 +5548,12 @@
     },
     "is-retry-allowed": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
       "integrity": "sha1-13hIi9CkZmo76KFIK58rqv7eqLQ="
     },
     "is-scoped": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-scoped/-/is-scoped-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-scoped/-/is-scoped-1.0.0.tgz",
       "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
       "requires": {
         "scoped-regex": "^1.0.0"
@@ -5566,7 +5566,7 @@
     },
     "is-symbol": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-symbol/-/is-symbol-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
       "requires": {
         "has-symbols": "^1.0.1"
@@ -5574,17 +5574,17 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-url": {
       "version": "1.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-url/-/is-url-1.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha1-BKTfRtKMTP89c9Af8Gq+sxihqlI="
     },
     "is-url-superb": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-url-superb/-/is-url-superb-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-url-superb/-/is-url-superb-3.0.0.tgz",
       "integrity": "sha1-uaHah4oaxzZZBH0eb07yLCCdPiU=",
       "requires": {
         "url-regex": "^5.0.0"
@@ -5592,27 +5592,27 @@
     },
     "is-utf8": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-utf8/-/is-utf8-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-valid-glob": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
       "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-windows/-/is-windows-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0="
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "is2": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is2/-/is2-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is2/-/is2-2.0.1.tgz",
       "integrity": "sha1-isNVZEhAkhzkNdlPBdOpRjTTSBo=",
       "requires": {
         "deep-is": "^0.1.3",
@@ -5622,7 +5622,7 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
@@ -5632,12 +5632,12 @@
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "issue-regex": {
@@ -5647,12 +5647,12 @@
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
     },
     "js-yaml": {
       "version": "3.13.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-yaml/-/js-yaml-3.13.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
       "requires": {
         "argparse": "^1.0.7",
@@ -5661,17 +5661,17 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-2.5.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q="
     },
     "json-buffer": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-buffer/-/json-buffer-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
     "json-parse-better-errors": {
@@ -5681,32 +5681,32 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
       "version": "3.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json3/-/json3-3.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
     },
     "json5": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json5/-/json5-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json5/-/json5-2.1.1.tgz",
       "integrity": "sha1-gbbLBOm6SW8ccAXQe0NoomOPkLY=",
       "requires": {
         "minimist": "^1.2.0"
@@ -5714,19 +5714,19 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "jsonschema": {
       "version": "1.2.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsonschema/-/jsonschema-1.2.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsonschema/-/jsonschema-1.2.5.tgz",
       "integrity": "sha1-uradl/oolGrsClapzCZtI/6ArmE="
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -5737,7 +5737,7 @@
     },
     "jszip": {
       "version": "3.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jszip/-/jszip-3.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jszip/-/jszip-3.2.2.tgz",
       "integrity": "sha1-sUOBbffhBqlZepTHdJM4WtylvR0=",
       "requires": {
         "lie": "~3.3.0",
@@ -5748,12 +5748,12 @@
     },
     "just-extend": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/just-extend/-/just-extend-4.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/just-extend/-/just-extend-4.0.2.tgz",
       "integrity": "sha1-8/R/ffyg+YnFVBCn68iFSwcQivw="
     },
     "keyv": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/keyv/-/keyv-3.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/keyv/-/keyv-3.1.0.tgz",
       "integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
       "requires": {
         "json-buffer": "3.0.0"
@@ -5766,7 +5766,7 @@
     },
     "kuler": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kuler/-/kuler-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kuler/-/kuler-1.0.1.tgz",
       "integrity": "sha1-73x4TzbJ+24W3TFQ0VJneysCKKY=",
       "requires": {
         "colornames": "^1.1.1"
@@ -5782,7 +5782,7 @@
     },
     "launchpad": {
       "version": "0.7.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/launchpad/-/launchpad-0.7.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/launchpad/-/launchpad-0.7.4.tgz",
       "integrity": "sha1-CKejj0i5Y+c9xovoT5+Pl0xGwms=",
       "optional": true,
       "requires": {
@@ -5798,7 +5798,7 @@
       "dependencies": {
         "rimraf": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-3.0.0.tgz",
           "integrity": "sha1-YUF21LMBC3Xlw5DrDulvbcDOu5s=",
           "optional": true,
           "requires": {
@@ -5807,7 +5807,7 @@
         },
         "underscore": {
           "version": "1.9.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/underscore/-/underscore-1.9.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/underscore/-/underscore-1.9.2.tgz",
           "integrity": "sha1-DI1vU21vN4pa8mSnL3vsUP63zy8=",
           "optional": true
         }
@@ -5815,7 +5815,7 @@
     },
     "lazystream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lazystream/-/lazystream-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "requires": {
         "readable-stream": "^2.0.5"
@@ -5823,7 +5823,7 @@
     },
     "lcid": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lcid/-/lcid-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lcid/-/lcid-2.0.0.tgz",
       "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
       "requires": {
         "invert-kv": "^2.0.0"
@@ -5831,7 +5831,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/levn/-/levn-0.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -5841,7 +5841,7 @@
     },
     "lie": {
       "version": "3.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lie/-/lie-3.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lie/-/lie-3.3.0.tgz",
       "integrity": "sha1-3Pgt7lRfRgdNryAMfBxaCOD0D2o=",
       "requires": {
         "immediate": "~3.0.5"
@@ -5919,7 +5919,7 @@
         },
         "symbol-observable": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/symbol-observable/-/symbol-observable-1.0.1.tgz",
           "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
         }
       }
@@ -6022,7 +6022,7 @@
       "dependencies": {
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "requires": {
             "error-ex": "^1.3.1",
@@ -6031,14 +6031,14 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },
     "locate-path": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "requires": {
         "p-locate": "^3.0.0",
@@ -6052,7 +6052,7 @@
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "requires": {
         "lodash._basecopy": "^3.0.0",
@@ -6061,37 +6061,37 @@
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
     },
     "lodash._basecreate": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.create": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.create/-/lodash.create-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "requires": {
         "lodash._baseassign": "^3.0.0",
@@ -6101,42 +6101,42 @@
     },
     "lodash.defaults": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
     "lodash.difference": {
       "version": "4.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
     },
     "lodash.flatten": {
       "version": "4.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
     "lodash.isequal": {
       "version": "4.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "requires": {
         "lodash._getnative": "^3.0.0",
@@ -6146,17 +6146,17 @@
     },
     "lodash.padend": {
       "version": "4.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
     },
     "lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "lodash.template": {
       "version": "4.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.template/-/lodash.template-4.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.template/-/lodash.template-4.5.0.tgz",
       "integrity": "sha1-+XYZXPPzR9DV9SSDVp/oAxzM6Ks=",
       "requires": {
         "lodash._reinterpolate": "^3.0.0",
@@ -6165,7 +6165,7 @@
     },
     "lodash.templatesettings": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
       "integrity": "sha1-5IExDwSdPPbUfpEq0JMTsVTw+zM=",
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
@@ -6173,12 +6173,12 @@
     },
     "lodash.union": {
       "version": "4.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.union/-/lodash.union-4.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
     },
     "lodash.zip": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.zip/-/lodash.zip-4.2.0.tgz",
       "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA="
     },
     "log-symbols": {
@@ -6212,7 +6212,7 @@
     },
     "logform": {
       "version": "1.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/logform/-/logform-1.10.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/logform/-/logform-1.10.0.tgz",
       "integrity": "sha1-ydVZhxTJK1RuI/TngUfEDx4CAS4=",
       "requires": {
         "colors": "^1.2.1",
@@ -6224,19 +6224,19 @@
       "dependencies": {
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "lolex": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lolex/-/lolex-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lolex/-/lolex-4.2.0.tgz",
       "integrity": "sha1-3b1/YhPKHqWCaQGrEiK2XXFLPNc="
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -6253,7 +6253,7 @@
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lower-case/-/lower-case-1.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
     "lowercase-keys": {
@@ -6272,14 +6272,14 @@
       "dependencies": {
         "yallist": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         }
       }
     },
     "magic-string": {
       "version": "0.22.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/magic-string/-/magic-string-0.22.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/magic-string/-/magic-string-0.22.5.tgz",
       "integrity": "sha1-jpz1r930Q4XB2lvCpqDb0QsDZX4=",
       "requires": {
         "vlq": "^0.2.2"
@@ -6295,14 +6295,14 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },
     "map-age-cleaner": {
       "version": "0.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
       "requires": {
         "p-defer": "^1.0.0"
@@ -6310,7 +6310,7 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
     "map-obj": {
@@ -6325,7 +6325,7 @@
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
@@ -6333,7 +6333,7 @@
     },
     "matcher": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/matcher/-/matcher-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/matcher/-/matcher-1.1.1.tgz",
       "integrity": "sha1-UdgwHhOPhAmCszixFrsMCa9iwcI=",
       "requires": {
         "escape-string-regexp": "^1.0.4"
@@ -6341,12 +6341,12 @@
     },
     "math-random": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/math-random/-/math-random-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/math-random/-/math-random-1.0.4.tgz",
       "integrity": "sha1-XdaUPJOFSCZwFtTjTwV1gwgMUUw="
     },
     "md5": {
       "version": "2.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/md5/-/md5-2.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/md5/-/md5-2.2.1.tgz",
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "requires": {
         "charenc": "~0.0.1",
@@ -6356,19 +6356,19 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         }
       }
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mem/-/mem-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mem/-/mem-4.3.0.tgz",
       "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
       "requires": {
         "map-age-cleaner": "^0.1.1",
@@ -6378,7 +6378,7 @@
       "dependencies": {
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
           "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs="
         }
       }
@@ -6401,12 +6401,12 @@
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
             "locate-path": "^2.0.0"
@@ -6414,7 +6414,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
             "p-locate": "^2.0.0",
@@ -6423,7 +6423,7 @@
         },
         "p-limit": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-limit/-/p-limit-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
           "requires": {
             "p-try": "^1.0.0"
@@ -6431,7 +6431,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
             "p-limit": "^1.1.0"
@@ -6439,12 +6439,12 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-try/-/p-try-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         },
         "read-pkg-up": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "requires": {
             "find-up": "^2.0.0",
@@ -6463,12 +6463,12 @@
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merge-stream": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "requires": {
         "readable-stream": "^2.0.1"
@@ -6476,12 +6476,12 @@
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
       "version": "3.1.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-3.1.10.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "requires": {
         "arr-diff": "^4.0.0",
@@ -6501,17 +6501,17 @@
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime/-/mime-1.6.0.tgz",
       "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
     },
     "mime-db": {
       "version": "1.43.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime-db/-/mime-db-1.43.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime-db/-/mime-db-1.43.0.tgz",
       "integrity": "sha1-ChLgUCZQ5HPXNVNQUOfI9OtPrlg="
     },
     "mime-types": {
       "version": "2.1.26",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime-types/-/mime-types-2.1.26.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime-types/-/mime-types-2.1.26.tgz",
       "integrity": "sha1-nJIfwJt+FJpl39wNpNIJlyALCgY=",
       "requires": {
         "mime-db": "1.43.0"
@@ -6519,12 +6519,12 @@
     },
     "mimic-fn": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI="
     },
     "mimic-response": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-response/-/mimic-response-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs="
     },
     "minify": {
@@ -6558,7 +6558,7 @@
     },
     "minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc="
     },
     "minimatch": {
@@ -6571,7 +6571,7 @@
     },
     "minimatch-all": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimatch-all/-/minimatch-all-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimatch-all/-/minimatch-all-1.1.0.tgz",
       "integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
       "requires": {
         "minimatch": "^3.0.2"
@@ -6593,7 +6593,7 @@
     },
     "minipass": {
       "version": "2.9.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minipass/-/minipass-2.9.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minipass/-/minipass-2.9.0.tgz",
       "integrity": "sha1-5xN2Ln0+Mv7YAxFc+T4EvKn8yaY=",
       "requires": {
         "safe-buffer": "^5.1.2",
@@ -6602,7 +6602,7 @@
     },
     "minizlib": {
       "version": "1.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minizlib/-/minizlib-1.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minizlib/-/minizlib-1.3.3.tgz",
       "integrity": "sha1-IpDeloGKNMKVUcio0wEha9Zahh0=",
       "requires": {
         "minipass": "^2.9.0"
@@ -6610,7 +6610,7 @@
     },
     "mixin-deep": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "requires": {
         "for-in": "^1.0.2",
@@ -6619,7 +6619,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -6637,7 +6637,7 @@
     },
     "mocha": {
       "version": "6.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mocha/-/mocha-6.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mocha/-/mocha-6.2.2.tgz",
       "integrity": "sha1-XYmH4olAyviVen12ZLkQ3Fsv6iA=",
       "requires": {
         "ansi-colors": "3.2.3",
@@ -6667,12 +6667,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
         },
         "debug": {
           "version": "3.2.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "requires": {
             "ms": "^2.1.1"
@@ -6680,7 +6680,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob/-/glob-7.1.3.tgz",
           "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -6693,12 +6693,12 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
           "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -6708,7 +6708,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -6716,7 +6716,7 @@
         },
         "yargs": {
           "version": "13.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs/-/yargs-13.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs/-/yargs-13.3.0.tgz",
           "integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
           "requires": {
             "cliui": "^5.0.0",
@@ -6735,17 +6735,17 @@
     },
     "mout": {
       "version": "1.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mout/-/mout-1.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mout/-/mout-1.2.2.tgz",
       "integrity": "sha1-ybcYpJmAagYyzt4XjoD0NiWed30="
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multer": {
       "version": "1.4.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/multer/-/multer-1.4.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/multer/-/multer-1.4.2.tgz",
       "integrity": "sha1-Lx9NEtuu66dMs35iPyNL9NPSBXo=",
       "requires": {
         "append-field": "^1.0.0",
@@ -6760,7 +6760,7 @@
     },
     "multipipe": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/multipipe/-/multipipe-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/multipipe/-/multipipe-1.0.2.tgz",
       "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
       "requires": {
         "duplexer2": "^0.1.2",
@@ -6769,12 +6769,12 @@
     },
     "mute-stream": {
       "version": "0.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "mz": {
       "version": "2.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mz/-/mz-2.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mz/-/mz-2.7.0.tgz",
       "integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
       "requires": {
         "any-promise": "^1.0.0",
@@ -6784,7 +6784,7 @@
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nanomatch/-/nanomatch-1.2.13.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "requires": {
         "arr-diff": "^4.0.0",
@@ -6802,18 +6802,18 @@
     },
     "native-promise-only": {
       "version": "0.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/native-promise-only/-/native-promise-only-0.8.1.tgz",
       "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "negotiator": {
       "version": "0.6.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/negotiator/-/negotiator-0.6.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs="
     },
     "nice-try": {
@@ -6823,7 +6823,7 @@
     },
     "nise": {
       "version": "1.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nise/-/nise-1.5.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nise/-/nise-1.5.3.tgz",
       "integrity": "sha1-nSz+N9RPVzF3ZsbpQIo1nF06wfc=",
       "requires": {
         "@sinonjs/formatio": "^3.2.1",
@@ -6835,12 +6835,12 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "lolex": {
           "version": "5.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lolex/-/lolex-5.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lolex/-/lolex-5.1.2.tgz",
           "integrity": "sha1-lTaU0JjOfAe8XtbQ5CvGwMbVo2c=",
           "requires": {
             "@sinonjs/commons": "^1.7.0"
@@ -6848,7 +6848,7 @@
         },
         "path-to-regexp": {
           "version": "1.8.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
           "integrity": "sha1-iHs7qdhDk+h6CgufTLdWGYtTVIo=",
           "requires": {
             "isarray": "0.0.1"
@@ -6858,7 +6858,7 @@
     },
     "no-case": {
       "version": "2.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/no-case/-/no-case-2.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
       "requires": {
         "lower-case": "^1.1.1"
@@ -6866,7 +6866,7 @@
     },
     "node-environment-flags": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
       "integrity": "sha1-+pMCdfW/Xa4YjWGSsktMi7rD12o=",
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
@@ -6875,12 +6875,12 @@
     },
     "node-status-codes": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
     },
     "nomnom": {
       "version": "1.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nomnom/-/nomnom-1.8.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nomnom/-/nomnom-1.8.1.tgz",
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "requires": {
         "chalk": "~0.4.0",
@@ -6889,12 +6889,12 @@
       "dependencies": {
         "ansi-styles": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-1.0.0.tgz",
           "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "requires": {
             "ansi-styles": "~1.0.0",
@@ -6904,14 +6904,14 @@
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
         }
       }
     },
     "noms": {
       "version": "0.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/noms/-/noms-0.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/noms/-/noms-0.0.0.tgz",
       "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
       "dev": true,
       "requires": {
@@ -6921,13 +6921,13 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -6939,7 +6939,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -6958,7 +6958,7 @@
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
         "remove-trailing-separator": "^1.0.1"
@@ -6966,12 +6966,12 @@
     },
     "normalize-url": {
       "version": "4.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-url/-/normalize-url-4.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha1-RTNUCH5sqWlXvY9br3U/WYIUISk="
     },
     "np": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/np/-/np-4.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/np/-/np-4.0.2.tgz",
       "integrity": "sha1-vhZOqyFZ1qRc5f2u4navcaqieHM=",
       "requires": {
         "@samverschueren/stream-to-observable": "^0.3.0",
@@ -7006,7 +7006,7 @@
       "dependencies": {
         "del": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/del/-/del-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/del/-/del-3.0.0.tgz",
           "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
           "requires": {
             "globby": "^6.1.0",
@@ -7019,12 +7019,12 @@
         },
         "is-path-cwd": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
           "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
         },
         "is-path-in-cwd": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
           "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
           "requires": {
             "is-path-inside": "^1.0.0"
@@ -7032,7 +7032,7 @@
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
           "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "requires": {
             "path-is-inside": "^1.0.1"
@@ -7040,19 +7040,19 @@
         },
         "p-map": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-map/-/p-map-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-map/-/p-map-1.2.0.tgz",
           "integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s="
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },
     "npm-name": {
       "version": "5.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-name/-/npm-name-5.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-name/-/npm-name-5.5.0.tgz",
       "integrity": "sha1-OnOtvLBIikGkT/gg7VHcwyxyvQk=",
       "requires": {
         "got": "^9.6.0",
@@ -7066,7 +7066,7 @@
       "dependencies": {
         "got": {
           "version": "9.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-9.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/got/-/got-9.6.0.tgz",
           "integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
           "requires": {
             "@sindresorhus/is": "^0.14.0",
@@ -7084,7 +7084,7 @@
         },
         "is-scoped": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-scoped/-/is-scoped-2.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-scoped/-/is-scoped-2.1.0.tgz",
           "integrity": "sha1-/vBxN3Jli99b7kGGCCZ92ubTVm0=",
           "requires": {
             "scoped-regex": "^2.0.0"
@@ -7092,17 +7092,17 @@
         },
         "prepend-http": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-2.0.0.tgz",
           "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
         },
         "scoped-regex": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/scoped-regex/-/scoped-regex-2.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/scoped-regex/-/scoped-regex-2.1.0.tgz",
           "integrity": "sha1-e5voRdgf2dIdHsl8YaC3z4bSAV8="
         },
         "url-parse-lax": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
           "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
           "requires": {
             "prepend-http": "^2.0.0"
@@ -7125,7 +7125,7 @@
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
     },
     "object-assign": {
@@ -7135,12 +7135,12 @@
     },
     "object-component": {
       "version": "0.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-component/-/object-component-0.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
         "copy-descriptor": "^0.1.0",
@@ -7150,7 +7150,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -7158,12 +7158,12 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -7173,17 +7173,17 @@
     },
     "object-inspect": {
       "version": "1.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-inspect/-/object-inspect-1.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-inspect/-/object-inspect-1.7.0.tgz",
       "integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc="
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
         "isobject": "^3.0.0"
@@ -7191,7 +7191,7 @@
     },
     "object.assign": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.assign/-/object.assign-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "requires": {
         "define-properties": "^1.1.2",
@@ -7202,7 +7202,7 @@
     },
     "object.entries": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.entries/-/object.entries-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object.entries/-/object.entries-1.1.1.tgz",
       "integrity": "sha1-7hzwQVPeArsJP+wzaDkA9XzlOZs=",
       "requires": {
         "define-properties": "^1.1.3",
@@ -7213,7 +7213,7 @@
     },
     "object.getownpropertydescriptors": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
       "integrity": "sha1-Npvx+VktiridcS3O1cuBx8U1Jkk=",
       "requires": {
         "define-properties": "^1.1.3",
@@ -7222,7 +7222,7 @@
     },
     "object.omit": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.omit/-/object.omit-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
         "for-own": "^0.1.4",
@@ -7231,7 +7231,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
@@ -7239,12 +7239,12 @@
     },
     "obuf": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/obuf/-/obuf-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha1-Cb6jND1BhZ69RGKS0RydTbYZCE4="
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "requires": {
         "ee-first": "1.1.1"
@@ -7252,7 +7252,7 @@
     },
     "on-headers": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/on-headers/-/on-headers-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha1-dysK5qqlJcOZ5Imt+tkMQD6zwo8="
     },
     "once": {
@@ -7265,12 +7265,12 @@
     },
     "one-time": {
       "version": "0.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/one-time/-/one-time-0.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/one-time/-/one-time-0.0.4.tgz",
       "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
     },
     "onetime": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
         "mimic-fn": "^1.0.0"
@@ -7278,12 +7278,12 @@
     },
     "opener": {
       "version": "1.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/opener/-/opener-1.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/opener/-/opener-1.5.1.tgz",
       "integrity": "sha1-bS8Od/GgrwAyrKcWwsH7uOfoq+0="
     },
     "opn": {
       "version": "5.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/opn/-/opn-5.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/opn/-/opn-5.5.0.tgz",
       "integrity": "sha1-/HFk+rVtI1kExRw7J9pnWMo7m/w=",
       "requires": {
         "is-wsl": "^1.1.0"
@@ -7291,7 +7291,7 @@
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
         "minimist": "~0.0.1",
@@ -7300,7 +7300,7 @@
     },
     "optionator": {
       "version": "0.8.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/optionator/-/optionator-0.8.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
       "dev": true,
       "requires": {
@@ -7314,7 +7314,7 @@
     },
     "ordered-read-streams": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
       "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
       "requires": {
         "is-stream": "^1.0.1",
@@ -7323,12 +7323,12 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/os-locale/-/os-locale-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/os-locale/-/os-locale-3.1.0.tgz",
       "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
       "requires": {
         "execa": "^1.0.0",
@@ -7343,7 +7343,7 @@
     },
     "osenv": {
       "version": "0.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/osenv/-/osenv-0.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
       "requires": {
         "os-homedir": "^1.0.0",
@@ -7352,17 +7352,17 @@
     },
     "ow": {
       "version": "0.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ow/-/ow-0.10.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ow/-/ow-0.10.0.tgz",
       "integrity": "sha1-qsjPAkEQtM2x1E7RiJE/w0zB81w="
     },
     "p-cancelable": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-cancelable/-/p-cancelable-1.1.0.tgz",
       "integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw="
     },
     "p-defer": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-defer/-/p-defer-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
     "p-finally": {
@@ -7372,12 +7372,12 @@
     },
     "p-is-promise": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-is-promise/-/p-is-promise-2.1.0.tgz",
       "integrity": "sha1-kYzrrqJIpiz3/6uOO8qMX4gvxC4="
     },
     "p-limit": {
       "version": "2.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.2.2.tgz",
       "integrity": "sha1-YSebZ3IfUoeqHBOpp/u8SMkpGx4=",
       "requires": {
         "p-try": "^2.0.0"
@@ -7385,7 +7385,7 @@
     },
     "p-locate": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "requires": {
         "p-limit": "^2.0.0"
@@ -7393,12 +7393,12 @@
     },
     "p-map": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-map/-/p-map-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-map/-/p-map-2.1.0.tgz",
       "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU="
     },
     "p-memoize": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-memoize/-/p-memoize-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-memoize/-/p-memoize-2.1.0.tgz",
       "integrity": "sha1-msgMjPk3PFLf7Oaq4f0uMAYCiYo=",
       "requires": {
         "mem": "^4.0.0",
@@ -7415,7 +7415,7 @@
     },
     "p-try": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
     },
     "package-json": {
@@ -7431,12 +7431,12 @@
       "dependencies": {
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
         "got": {
           "version": "6.7.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-6.7.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "requires": {
             "create-error-class": "^3.0.0",
@@ -7454,7 +7454,7 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
           "integrity": "sha1-10RoFUM/XV7WQxzV3KIQSPZrOX4=",
           "requires": {
             "rc": "^1.1.6",
@@ -7463,7 +7463,7 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-url/-/registry-url-3.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-url/-/registry-url-3.1.0.tgz",
           "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "requires": {
             "rc": "^1.0.1"
@@ -7471,24 +7471,24 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/timed-out/-/timed-out-4.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
         "unzip-response": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-2.0.1.tgz",
           "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
         }
       }
     },
     "pako": {
       "version": "1.0.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pako/-/pako-1.0.10.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pako/-/pako-1.0.10.tgz",
       "integrity": "sha1-Qyi621CGpCaqkPVBl31JVdpclzI="
     },
     "param-case": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/param-case/-/param-case-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "requires": {
         "no-case": "^2.2.0"
@@ -7496,7 +7496,7 @@
     },
     "parent-module": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parent-module/-/parent-module-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
       "dev": true,
       "requires": {
@@ -7505,7 +7505,7 @@
     },
     "parse-glob": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-glob/-/parse-glob-3.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
         "glob-base": "^0.3.0",
@@ -7516,12 +7516,12 @@
       "dependencies": {
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
             "is-extglob": "^1.0.0"
@@ -7531,7 +7531,7 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
         "error-ex": "^1.2.0"
@@ -7539,17 +7539,17 @@
     },
     "parse-passwd": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
     "parse5": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
       "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg="
     },
     "parseqs": {
       "version": "0.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseqs/-/parseqs-0.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "requires": {
         "better-assert": "~1.0.0"
@@ -7557,7 +7557,7 @@
     },
     "parseuri": {
       "version": "0.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseuri/-/parseuri-0.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "requires": {
         "better-assert": "~1.0.0"
@@ -7565,17 +7565,17 @@
     },
     "parseurl": {
       "version": "1.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ="
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
     "path-exists": {
@@ -7605,7 +7605,7 @@
     },
     "path-to-regexp": {
       "version": "2.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
       "integrity": "sha1-Nc5/Mz1WFvHB4b/iZsOrouWy5wQ="
     },
     "path-type": {
@@ -7618,14 +7618,14 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },
     "pathval": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pathval/-/pathval-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
     "pause-stream": {
@@ -7638,7 +7638,7 @@
     },
     "pem": {
       "version": "1.14.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pem/-/pem-1.14.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pem/-/pem-1.14.3.tgz",
       "integrity": "sha1-NH5aXBlKX3YSuICD5FBC/MT7SQE=",
       "requires": {
         "es6-promisify": "^6.0.0",
@@ -7649,19 +7649,19 @@
       "dependencies": {
         "es6-promisify": {
           "version": "6.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-6.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-6.0.2.tgz",
           "integrity": "sha1-UlwjcluFEPXx8v61ofutk6k+KbQ="
         }
       }
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pend/-/pend-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
@@ -7671,7 +7671,7 @@
     },
     "pify": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-4.0.1.tgz",
       "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE="
     },
     "pinkie": {
@@ -7689,7 +7689,7 @@
     },
     "pkg-dir": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
       "requires": {
         "find-up": "^3.0.0"
@@ -7697,7 +7697,7 @@
     },
     "plist": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/plist/-/plist-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/plist/-/plist-2.1.0.tgz",
       "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
       "optional": true,
       "requires": {
@@ -7708,7 +7708,7 @@
       "dependencies": {
         "xmlbuilder": {
           "version": "8.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
           "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
           "optional": true
         }
@@ -7716,7 +7716,7 @@
     },
     "plylog": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/plylog/-/plylog-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/plylog/-/plylog-1.1.0.tgz",
       "integrity": "sha1-9vNU4q4LAfbbTtER9LOFXanDdBc=",
       "requires": {
         "logform": "^1.9.1",
@@ -7726,7 +7726,7 @@
     },
     "polymer-analyzer": {
       "version": "3.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-analyzer/-/polymer-analyzer-3.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polymer-analyzer/-/polymer-analyzer-3.2.4.tgz",
       "integrity": "sha1-fXY1ZiCiMo6LyeMORwaflykmDKE=",
       "requires": {
         "@babel/generator": "^7.0.0-beta.42",
@@ -7770,17 +7770,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -7792,7 +7792,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -7800,14 +7800,14 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
     "polymer-build": {
       "version": "3.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-build/-/polymer-build-3.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polymer-build/-/polymer-build-3.1.4.tgz",
       "integrity": "sha1-q1OfGhPYA1GLE7c//QkZhDHZgUI=",
       "requires": {
         "@babel/core": "^7.0.0",
@@ -7879,7 +7879,7 @@
       "dependencies": {
         "@types/mz": {
           "version": "0.0.31",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.31.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.31.tgz",
           "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
           "requires": {
             "@types/node": "*"
@@ -7887,7 +7887,7 @@
         },
         "@types/resolve": {
           "version": "0.0.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.7.tgz",
           "integrity": "sha1-spnBO+jXErG1AvsUoIQlKs74T00=",
           "requires": {
             "@types/node": "*"
@@ -7932,7 +7932,7 @@
     },
     "polymer-bundler": {
       "version": "4.0.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-bundler/-/polymer-bundler-4.0.10.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polymer-bundler/-/polymer-bundler-4.0.10.tgz",
       "integrity": "sha1-q8jTOXdlLwMQaNA0yBBIQegNTLs=",
       "requires": {
         "@types/babel-generator": "^6.25.1",
@@ -7956,14 +7956,14 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "polymer-project-config": {
       "version": "4.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-project-config/-/polymer-project-config-4.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polymer-project-config/-/polymer-project-config-4.0.3.tgz",
       "integrity": "sha1-7wwaZ2zkgJkHmGyOkQdFZg3oAk8=",
       "requires": {
         "@types/parse5": "^2.2.34",
@@ -7976,7 +7976,7 @@
     },
     "polyserve": {
       "version": "0.27.15",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polyserve/-/polyserve-0.27.15.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polyserve/-/polyserve-0.27.15.tgz",
       "integrity": "sha1-Jh+loIc8jZX9cGhZj0TJ2sIM+cQ=",
       "requires": {
         "@types/compression": "^0.0.33",
@@ -8017,12 +8017,12 @@
       "dependencies": {
         "mime": {
           "version": "2.4.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-2.4.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime/-/mime-2.4.4.tgz",
           "integrity": "sha1-vXuRE1/GsBzePpuuM9ZZtj2IV+U="
         },
         "opn": {
           "version": "3.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/opn/-/opn-3.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/opn/-/opn-3.0.3.tgz",
           "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
           "requires": {
             "object-assign": "^4.0.1"
@@ -8032,7 +8032,7 @@
     },
     "portfinder": {
       "version": "1.0.25",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/portfinder/-/portfinder-1.0.25.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/portfinder/-/portfinder-1.0.25.tgz",
       "integrity": "sha1-JU/TN/+6hp9LnTftwpgFnLTTXso=",
       "requires": {
         "async": "^2.6.2",
@@ -8042,7 +8042,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "requires": {
             "ms": "^2.1.1"
@@ -8050,40 +8050,40 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "preserve": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/preserve/-/preserve-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "pretty-bytes": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
     },
     "prismjs": {
       "version": "1.17.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prismjs/-/prismjs-1.17.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prismjs/-/prismjs-1.17.1.tgz",
       "integrity": "sha1-5mn8vUzdhzw1ECiBwzsU0NaFGb4=",
       "requires": {
         "clipboard": "^2.0.0"
@@ -8091,22 +8091,22 @@
     },
     "private": {
       "version": "0.1.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/private/-/private-0.1.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/private/-/private-0.1.8.tgz",
       "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8="
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/progress/-/progress-2.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/progress/-/progress-2.0.3.tgz",
       "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg="
     },
     "proxy-addr": {
       "version": "2.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/proxy-addr/-/proxy-addr-2.0.5.tgz",
       "integrity": "sha1-NMvWSi2B9LH9IedvnwbIpFKZ7jQ=",
       "requires": {
         "forwarded": "~0.1.2",
@@ -8120,12 +8120,12 @@
     },
     "psl": {
       "version": "1.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/psl/-/psl-1.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/psl/-/psl-1.7.0.tgz",
       "integrity": "sha1-8cTEeo75cWfepda79IFtc26ISjw="
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pump/-/pump-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pump/-/pump-3.0.0.tgz",
       "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -8134,22 +8134,22 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/q/-/q-1.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.5.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/qs/-/qs-6.5.2.tgz",
       "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "quick-lru": {
@@ -8159,7 +8159,7 @@
     },
     "randomatic": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/randomatic/-/randomatic-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/randomatic/-/randomatic-3.1.1.tgz",
       "integrity": "sha1-t3bvxZN1mE42xTey9RofCv8Noe0=",
       "requires": {
         "is-number": "^4.0.0",
@@ -8169,19 +8169,19 @@
       "dependencies": {
         "is-number": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-number/-/is-number-4.0.0.tgz",
           "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8="
         }
       }
     },
     "range-parser": {
       "version": "1.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/range-parser/-/range-parser-1.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE="
     },
     "raw-body": {
       "version": "2.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/raw-body/-/raw-body-2.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/raw-body/-/raw-body-2.4.0.tgz",
       "integrity": "sha1-oc5vucm8NWylLoklarWQWeE9AzI=",
       "requires": {
         "bytes": "3.1.0",
@@ -8210,7 +8210,7 @@
     },
     "read-all-stream": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "requires": {
         "pinkie-promise": "^2.0.0",
@@ -8229,7 +8229,7 @@
     },
     "read-pkg-up": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
       "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
       "requires": {
         "find-up": "^3.0.0",
@@ -8238,7 +8238,7 @@
     },
     "readable-stream": {
       "version": "2.3.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-2.3.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -8269,17 +8269,17 @@
     },
     "reduce-flatten": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
       "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
     },
     "regenerate": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerate/-/regenerate-1.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerate/-/regenerate-1.4.0.tgz",
       "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE="
     },
     "regenerate-unicode-properties": {
       "version": "8.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
       "integrity": "sha1-71Hg8OpK1CS3e/fLQfPgFccKPw4=",
       "requires": {
         "regenerate": "^1.4.0"
@@ -8287,12 +8287,12 @@
     },
     "regenerator-runtime": {
       "version": "0.11.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
     },
     "regenerator-transform": {
       "version": "0.14.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
       "integrity": "sha1-Oy/OThq3cywI9mXf2zFHScfd0vs=",
       "requires": {
         "private": "^0.1.6"
@@ -8300,7 +8300,7 @@
     },
     "regex-cache": {
       "version": "0.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regex-cache/-/regex-cache-0.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "requires": {
         "is-equal-shallow": "^0.1.3"
@@ -8308,7 +8308,7 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regex-not/-/regex-not-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "requires": {
         "extend-shallow": "^3.0.2",
@@ -8317,13 +8317,13 @@
     },
     "regexpp": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regexpp/-/regexpp-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
       "dev": true
     },
     "regexpu-core": {
       "version": "4.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regexpu-core/-/regexpu-core-4.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regexpu-core/-/regexpu-core-4.6.0.tgz",
       "integrity": "sha1-IDfBizJ8/Oim/qKk7EQfJDKvuLY=",
       "requires": {
         "regenerate": "^1.4.0",
@@ -8345,7 +8345,7 @@
     },
     "registry-url": {
       "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-url/-/registry-url-5.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-url/-/registry-url-5.1.0.tgz",
       "integrity": "sha1-6YM0tQ1UNLgRNrROxjjZwgCcUAk=",
       "requires": {
         "rc": "^1.2.8"
@@ -8353,12 +8353,12 @@
     },
     "regjsgen": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regjsgen/-/regjsgen-0.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regjsgen/-/regjsgen-0.5.1.tgz",
       "integrity": "sha1-SPC/Gl6iBRlpKcDZeYtC0e2YRDw="
     },
     "regjsparser": {
       "version": "0.6.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regjsparser/-/regjsparser-0.6.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regjsparser/-/regjsparser-0.6.2.tgz",
       "integrity": "sha1-/WLHU5kUZ9nR/+Cp9n8npSkCS5Y=",
       "requires": {
         "jsesc": "~0.5.0"
@@ -8366,34 +8366,34 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
     },
     "relateurl": {
       "version": "0.2.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/relateurl/-/relateurl-0.2.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeat-element/-/repeat-element-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4="
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
         "is-finite": "^1.0.0"
@@ -8401,7 +8401,7 @@
     },
     "replace": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/replace/-/replace-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/replace/-/replace-1.1.1.tgz",
       "integrity": "sha1-PRteWJa9VcNlpCqNbiILB6b11jU=",
       "requires": {
         "colors": "1.2.4",
@@ -8411,12 +8411,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "cliui": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cliui/-/cliui-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cliui/-/cliui-4.1.0.tgz",
           "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
           "requires": {
             "string-width": "^2.1.1",
@@ -8426,17 +8426,17 @@
         },
         "colors": {
           "version": "1.2.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colors/-/colors-1.2.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/colors/-/colors-1.2.4.tgz",
           "integrity": "sha1-4MtB0+SyCAazv8J/RVnwG5S8L3w="
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-caller-file/-/get-caller-file-1.0.3.tgz",
           "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -8444,12 +8444,12 @@
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/require-main-filename/-/require-main-filename-1.0.1.tgz",
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "requires": {
             "string-width": "^1.0.1",
@@ -8458,7 +8458,7 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-1.0.2.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -8468,7 +8468,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -8478,7 +8478,7 @@
         },
         "yargs": {
           "version": "12.0.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs/-/yargs-12.0.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs/-/yargs-12.0.5.tgz",
           "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
           "requires": {
             "cliui": "^4.0.0",
@@ -8497,7 +8497,7 @@
         },
         "yargs-parser": {
           "version": "11.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-11.1.1.tgz",
           "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
           "requires": {
             "camelcase": "^5.0.0",
@@ -8508,12 +8508,12 @@
     },
     "replace-ext": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/replace-ext/-/replace-ext-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
     },
     "request": {
       "version": "2.88.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/request/-/request-2.88.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/request/-/request-2.88.0.tgz",
       "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -8540,27 +8540,27 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs="
     },
     "requirejs": {
       "version": "2.3.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/requirejs/-/requirejs-2.3.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/requirejs/-/requirejs-2.3.6.tgz",
       "integrity": "sha1-5Qk9lgHCgpJRJYwLlEXU0Z+p58k="
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/requires-port/-/requires-port-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.14.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve/-/resolve-1.14.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/resolve/-/resolve-1.14.2.tgz",
       "integrity": "sha1-2/MdD6mLHymqUWl4O5wpDLhl/qI=",
       "requires": {
         "path-parse": "^1.0.6"
@@ -8568,7 +8568,7 @@
     },
     "resolve-dir": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "requires": {
         "expand-tilde": "^2.0.0",
@@ -8577,18 +8577,18 @@
     },
     "resolve-from": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-from/-/resolve-from-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
       "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "responselike": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/responselike/-/responselike-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/responselike/-/responselike-1.0.2.tgz",
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "requires": {
         "lowercase-keys": "^1.0.0"
@@ -8596,7 +8596,7 @@
     },
     "restore-cursor": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
         "onetime": "^2.0.0",
@@ -8605,12 +8605,12 @@
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ret/-/ret-0.1.15.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ret/-/ret-0.1.15.tgz",
       "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w="
     },
     "rimraf": {
       "version": "2.7.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.7.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
       "requires": {
         "glob": "^7.1.3"
@@ -8628,7 +8628,7 @@
       "dependencies": {
         "acorn": {
           "version": "7.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-7.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn/-/acorn-7.1.0.tgz",
           "integrity": "sha1-lJ028sKSU12mAig1hsJHfFfrLWw="
         }
       }
@@ -8656,7 +8656,7 @@
     },
     "rxjs": {
       "version": "6.5.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rxjs/-/rxjs-6.5.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rxjs/-/rxjs-6.5.4.tgz",
       "integrity": "sha1-4Hd/4NGEzseHLfFH8wNXLUFOIRw=",
       "requires": {
         "tslib": "^1.9.0"
@@ -8669,7 +8669,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -8682,7 +8682,7 @@
     },
     "samsam": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/samsam/-/samsam-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/samsam/-/samsam-1.1.2.tgz",
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
     },
     "sass": {
@@ -8695,7 +8695,7 @@
     },
     "sauce-connect-launcher": {
       "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sauce-connect-launcher/-/sauce-connect-launcher-1.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sauce-connect-launcher/-/sauce-connect-launcher-1.3.1.tgz",
       "integrity": "sha1-MRN/V7D3F24cBSW3+wnG2nRmR88=",
       "optional": true,
       "requires": {
@@ -8708,17 +8708,17 @@
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sax/-/sax-1.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sax/-/sax-1.2.4.tgz",
       "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "scoped-regex": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/scoped-regex/-/scoped-regex-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/scoped-regex/-/scoped-regex-1.0.0.tgz",
       "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
     },
     "secure-compare": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/secure-compare/-/secure-compare-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/secure-compare/-/secure-compare-3.0.1.tgz",
       "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM="
     },
     "select": {
@@ -8729,12 +8729,12 @@
     },
     "select-hose": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/select-hose/-/select-hose-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selenium-standalone": {
       "version": "6.17.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/selenium-standalone/-/selenium-standalone-6.17.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/selenium-standalone/-/selenium-standalone-6.17.0.tgz",
       "integrity": "sha1-DyS2kYNiBe6bw9em8gfryygXDNk=",
       "optional": true,
       "requires": {
@@ -8755,7 +8755,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "optional": true,
           "requires": {
@@ -8764,7 +8764,7 @@
         },
         "fd-slicer": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fd-slicer/-/fd-slicer-1.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
           "optional": true,
           "requires": {
@@ -8773,19 +8773,19 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "optional": true
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "optional": true
         },
         "yauzl": {
           "version": "2.10.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yauzl/-/yauzl-2.10.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yauzl/-/yauzl-2.10.0.tgz",
           "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
           "optional": true,
           "requires": {
@@ -8797,7 +8797,7 @@
     },
     "selenium-webdriver": {
       "version": "4.0.0-alpha.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.5.tgz",
       "integrity": "sha1-5Gg7Pb+CfXDfCafkO/AuutIPp8E=",
       "requires": {
         "jszip": "^3.1.5",
@@ -8808,7 +8808,7 @@
       "dependencies": {
         "tmp": {
           "version": "0.0.30",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tmp/-/tmp-0.0.30.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tmp/-/tmp-0.0.30.tgz",
           "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
           "requires": {
             "os-tmpdir": "~1.0.1"
@@ -8818,7 +8818,7 @@
     },
     "semver": {
       "version": "5.7.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.7.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-5.7.1.tgz",
       "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
     },
     "semver-diff": {
@@ -8831,7 +8831,7 @@
     },
     "send": {
       "version": "0.16.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.16.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/send/-/send-0.16.2.tgz",
       "integrity": "sha1-bsyh4PjBVtFBWXVZhI32RzCmu8E=",
       "requires": {
         "debug": "2.6.9",
@@ -8851,7 +8851,7 @@
       "dependencies": {
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
             "depd": "~1.1.2",
@@ -8862,29 +8862,29 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "mime": {
           "version": "1.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-1.4.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime/-/mime-1.4.1.tgz",
           "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY="
         },
         "setprototypeof": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
         },
         "statuses": {
           "version": "1.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/statuses/-/statuses-1.4.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/statuses/-/statuses-1.4.0.tgz",
           "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
         }
       }
     },
     "serve-static": {
       "version": "1.14.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/serve-static/-/serve-static-1.14.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/serve-static/-/serve-static-1.14.1.tgz",
       "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
       "requires": {
         "encodeurl": "~1.0.2",
@@ -8895,12 +8895,12 @@
       "dependencies": {
         "ms": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
           "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
         },
         "send": {
           "version": "0.17.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
           "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
           "requires": {
             "debug": "2.6.9",
@@ -8922,27 +8922,27 @@
     },
     "server-destroy": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/server-destroy/-/server-destroy-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0="
     },
     "serviceworker-cache-polyfill": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
       "integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves="
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "set-value": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-value/-/set-value-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -8953,7 +8953,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -8963,12 +8963,12 @@
     },
     "setprototypeof": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM="
     },
     "shady-css-parser": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
       "integrity": "sha1-U03HnIyliExe2SpOWhPW2GO8pCg="
     },
     "shebang-command": {
@@ -8991,7 +8991,7 @@
     },
     "simple-swizzle": {
       "version": "0.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
         "is-arrayish": "^0.3.1"
@@ -8999,14 +8999,14 @@
       "dependencies": {
         "is-arrayish": {
           "version": "0.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.3.2.tgz",
           "integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM="
         }
       }
     },
     "sinon": {
       "version": "7.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon/-/sinon-7.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sinon/-/sinon-7.5.0.tgz",
       "integrity": "sha1-6UiOpGYHDqkI/USj1keP1JI8Z+w=",
       "requires": {
         "@sinonjs/commons": "^1.4.0",
@@ -9020,7 +9020,7 @@
       "dependencies": {
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "requires": {
             "has-flag": "^3.0.0"
@@ -9030,17 +9030,17 @@
     },
     "sinon-chai": {
       "version": "2.14.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sinon-chai/-/sinon-chai-2.14.0.tgz",
       "integrity": "sha1-2n3UzIPNaiYLZ8yg96n9riahIF0="
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon/-/snapdragon-0.8.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "requires": {
         "base": "^0.11.1",
@@ -9055,7 +9055,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -9063,7 +9063,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -9071,14 +9071,14 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "requires": {
         "define-property": "^1.0.0",
@@ -9088,7 +9088,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -9096,7 +9096,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -9104,7 +9104,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -9112,7 +9112,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -9124,7 +9124,7 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "requires": {
         "kind-of": "^3.2.0"
@@ -9132,12 +9132,12 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -9147,7 +9147,7 @@
     },
     "socket.io": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io/-/socket.io-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io/-/socket.io-2.3.0.tgz",
       "integrity": "sha1-zXYu1qT67KWbwfPiQ8CWkxHrc/s=",
       "requires": {
         "debug": "~4.1.0",
@@ -9160,7 +9160,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
@@ -9168,19 +9168,19 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "socket.io-adapter": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
       "integrity": "sha1-qz8Nb2a4/H/KOVmrWZH4IiF4m+k="
     },
     "socket.io-client": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-client/-/socket.io-client-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io-client/-/socket.io-client-2.3.0.tgz",
       "integrity": "sha1-FNW6LgC5vNFFrkQ6uWs/hsvMG7Q=",
       "requires": {
         "backo2": "1.0.2",
@@ -9201,12 +9201,12 @@
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
@@ -9214,17 +9214,17 @@
         },
         "isarray": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         },
         "socket.io-parser": {
           "version": "3.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
           "integrity": "sha1-K1KpalCf3zFEC6QP7WCUx9TxJi8=",
           "requires": {
             "component-emitter": "1.2.1",
@@ -9234,7 +9234,7 @@
           "dependencies": {
             "debug": {
               "version": "3.1.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
               "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
               "requires": {
                 "ms": "2.0.0"
@@ -9242,7 +9242,7 @@
             },
             "ms": {
               "version": "2.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
@@ -9251,7 +9251,7 @@
     },
     "socket.io-parser": {
       "version": "3.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-parser/-/socket.io-parser-3.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io-parser/-/socket.io-parser-3.4.0.tgz",
       "integrity": "sha1-Nwu0oVHfL3fOM0X/VacHLMbpVlo=",
       "requires": {
         "component-emitter": "1.2.1",
@@ -9261,12 +9261,12 @@
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
@@ -9274,24 +9274,24 @@
         },
         "isarray": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
     },
     "source-map-resolve": {
       "version": "0.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
       "requires": {
         "atob": "^2.1.2",
@@ -9312,7 +9312,7 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "spdx-correct": {
@@ -9345,7 +9345,7 @@
     },
     "spdy": {
       "version": "3.4.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdy/-/spdy-3.4.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "requires": {
         "debug": "^2.6.8",
@@ -9358,7 +9358,7 @@
     },
     "spdy-transport": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdy-transport/-/spdy-transport-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdy-transport/-/spdy-transport-2.1.1.tgz",
       "integrity": "sha1-xUgV1zhYqt0GzmMAHn0l+mRBYjs=",
       "requires": {
         "debug": "^2.6.8",
@@ -9380,7 +9380,7 @@
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/split-string/-/split-string-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "requires": {
         "extend-shallow": "^3.0.0"
@@ -9388,12 +9388,12 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sshpk/-/sshpk-1.16.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "requires": {
         "asn1": "~0.2.3",
@@ -9409,17 +9409,17 @@
     },
     "stable": {
       "version": "0.1.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stable/-/stable-0.1.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stable/-/stable-0.1.8.tgz",
       "integrity": "sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88="
     },
     "stack-trace": {
       "version": "0.0.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stack-trace/-/stack-trace-0.0.10.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "stacky": {
       "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stacky/-/stacky-1.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stacky/-/stacky-1.3.1.tgz",
       "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
       "requires": {
         "chalk": "^1.1.1",
@@ -9428,17 +9428,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -9450,12 +9450,12 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -9463,14 +9463,14 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
         "define-property": "^0.2.5",
@@ -9479,7 +9479,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -9489,12 +9489,12 @@
     },
     "statuses": {
       "version": "1.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/statuses/-/statuses-1.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stream": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stream/-/stream-0.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stream/-/stream-0.0.2.tgz",
       "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
       "requires": {
         "emitter-component": "^1.1.1"
@@ -9511,17 +9511,17 @@
     },
     "stream-shift": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stream-shift/-/stream-shift-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0="
     },
     "streamsearch": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/streamsearch/-/streamsearch-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "string-width": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
@@ -9530,7 +9530,7 @@
     },
     "string.prototype.trimleft": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
       "integrity": "sha1-m9uKxqvW1gKxek7TIYcNL43O/HQ=",
       "requires": {
         "define-properties": "^1.1.3",
@@ -9539,7 +9539,7 @@
     },
     "string.prototype.trimright": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
       "integrity": "sha1-RAMUsVmWyGbOigNBiU1FGGIAxdk=",
       "requires": {
         "define-properties": "^1.1.3",
@@ -9548,7 +9548,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -9556,7 +9556,7 @@
     },
     "strip-ansi": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
         "ansi-regex": "^3.0.0"
@@ -9569,7 +9569,7 @@
     },
     "strip-bom-stream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "requires": {
         "first-chunk-stream": "^1.0.0",
@@ -9578,7 +9578,7 @@
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
             "is-utf8": "^0.2.0"
@@ -9598,12 +9598,12 @@
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "6.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-6.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-6.0.0.tgz",
       "integrity": "sha1-ds/nQs8fQbubHCmtAwaMBbTA5Ao=",
       "requires": {
         "has-flag": "^3.0.0"
@@ -9625,7 +9625,7 @@
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "requires": {
             "has-flag": "^3.0.0"
@@ -9633,7 +9633,7 @@
           "dependencies": {
             "has-flag": {
               "version": "3.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-3.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-3.0.0.tgz",
               "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             }
           }
@@ -9642,7 +9642,7 @@
     },
     "sw-precache": {
       "version": "5.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sw-precache/-/sw-precache-5.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sw-precache/-/sw-precache-5.2.1.tgz",
       "integrity": "sha1-BhNPMZ7saPO5WDzppwNrHBGfcXk=",
       "requires": {
         "dom-urls": "^1.1.0",
@@ -9659,12 +9659,12 @@
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "requires": {
             "camelcase": "^2.0.0",
@@ -9673,7 +9673,7 @@
         },
         "find-up": {
           "version": "1.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-1.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
             "path-exists": "^2.0.0",
@@ -9682,7 +9682,7 @@
         },
         "indent-string": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent-string/-/indent-string-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "requires": {
             "repeating": "^2.0.0"
@@ -9690,7 +9690,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -9702,12 +9702,12 @@
         },
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         },
         "meow": {
           "version": "3.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/meow/-/meow-3.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "requires": {
             "camelcase-keys": "^2.0.0",
@@ -9724,12 +9724,12 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
             "pinkie-promise": "^2.0.0"
@@ -9737,7 +9737,7 @@
         },
         "path-type": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-type/-/path-type-1.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -9747,12 +9747,12 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "read-pkg": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-1.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
             "load-json-file": "^1.0.0",
@@ -9762,7 +9762,7 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
             "find-up": "^1.0.0",
@@ -9771,7 +9771,7 @@
         },
         "redent": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/redent/-/redent-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/redent/-/redent-1.0.0.tgz",
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "requires": {
             "indent-string": "^2.1.0",
@@ -9780,7 +9780,7 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
             "is-utf8": "^0.2.0"
@@ -9788,7 +9788,7 @@
         },
         "strip-indent": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-1.0.1.tgz",
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "requires": {
             "get-stdin": "^4.0.1"
@@ -9796,14 +9796,14 @@
         },
         "trim-newlines": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-1.0.0.tgz",
           "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
         }
       }
     },
     "sw-toolbox": {
       "version": "3.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
       "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
       "requires": {
         "path-to-regexp": "^1.0.1",
@@ -9812,12 +9812,12 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "path-to-regexp": {
           "version": "1.8.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
           "integrity": "sha1-iHs7qdhDk+h6CgufTLdWGYtTVIo=",
           "requires": {
             "isarray": "0.0.1"
@@ -9827,7 +9827,7 @@
     },
     "symbol-observable": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ="
     },
     "table": {
@@ -9844,13 +9844,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "slice-ansi": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/slice-ansi/-/slice-ansi-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/slice-ansi/-/slice-ansi-2.1.0.tgz",
           "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
           "dev": true,
           "requires": {
@@ -9861,7 +9861,7 @@
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -9872,7 +9872,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -9883,7 +9883,7 @@
     },
     "table-layout": {
       "version": "0.4.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/table-layout/-/table-layout-0.4.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/table-layout/-/table-layout-0.4.5.tgz",
       "integrity": "sha1-2QbeaiX6CcDJDR0I7Ngz7O3Lc3g=",
       "requires": {
         "array-back": "^2.0.0",
@@ -9895,7 +9895,7 @@
       "dependencies": {
         "array-back": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
           "integrity": "sha1-aHdHHVHsycm/phNvtsfV/ml0gCI=",
           "requires": {
             "typical": "^2.6.1"
@@ -9903,14 +9903,14 @@
         },
         "typical": {
           "version": "2.6.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
           "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
         }
       }
     },
     "tar": {
       "version": "4.4.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar/-/tar-4.4.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tar/-/tar-4.4.2.tgz",
       "integrity": "sha1-YGhSEbpGs4hHsa5+4aJNdEos1GI=",
       "requires": {
         "chownr": "^1.0.1",
@@ -9924,7 +9924,7 @@
     },
     "tar-stream": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar-stream/-/tar-stream-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tar-stream/-/tar-stream-2.0.0.tgz",
       "integrity": "sha1-iCm7+DBnvAKIqQidtJxWvjlbauo=",
       "optional": true,
       "requires": {
@@ -9950,7 +9950,7 @@
     },
     "tcp-port-used": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tcp-port-used/-/tcp-port-used-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tcp-port-used/-/tcp-port-used-1.0.1.tgz",
       "integrity": "sha1-RgYQeOLTjHOXmiwsErWmdOZonXA=",
       "requires": {
         "debug": "4.1.0",
@@ -9959,7 +9959,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.0.tgz",
           "integrity": "sha1-NzaHv/pnizixzZH4YbY4UANd3Ic=",
           "requires": {
             "ms": "^2.1.1"
@@ -9967,14 +9967,14 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "temp": {
       "version": "0.8.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/temp/-/temp-0.8.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/temp/-/temp-0.8.4.tgz",
       "integrity": "sha1-jJejOkdwBy4KBfkZOWx2ZafdWfI=",
       "optional": true,
       "requires": {
@@ -9983,7 +9983,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.6.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
           "optional": true,
           "requires": {
@@ -10026,7 +10026,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         }
       }
@@ -10042,7 +10042,7 @@
     },
     "ternary-stream": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ternary-stream/-/ternary-stream-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ternary-stream/-/ternary-stream-2.1.1.tgz",
       "integrity": "sha1-StZLmGaNeWoIWvLEk4haQ1qKi/w=",
       "requires": {
         "duplexify": "^3.5.0",
@@ -10063,23 +10063,23 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
     },
     "text-hex": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-hex/-/text-hex-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha1-adycGxdEbueakr9biEu0uRJ1BvU="
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "thenify": {
       "version": "3.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/thenify/-/thenify-3.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/thenify/-/thenify-3.3.0.tgz",
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "requires": {
         "any-promise": "^1.0.0"
@@ -10087,7 +10087,7 @@
     },
     "thenify-all": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/thenify-all/-/thenify-all-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "requires": {
         "thenify": ">= 3.1.0 < 4"
@@ -10100,7 +10100,7 @@
     },
     "through2": {
       "version": "2.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2/-/through2-2.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2/-/through2-2.0.5.tgz",
       "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "requires": {
         "readable-stream": "~2.3.6",
@@ -10109,7 +10109,7 @@
     },
     "through2-filter": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "requires": {
         "through2": "~2.0.0",
@@ -10118,7 +10118,7 @@
     },
     "timed-out": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/timed-out/-/timed-out-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/timed-out/-/timed-out-2.0.0.tgz",
       "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo="
     },
     "tiny-emitter": {
@@ -10129,7 +10129,7 @@
     },
     "tlds": {
       "version": "1.207.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tlds/-/tlds-1.207.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tlds/-/tlds-1.207.0.tgz",
       "integrity": "sha1-RZJk5kTPY93All/s44mJEyhrGv0="
     },
     "tmp": {
@@ -10142,7 +10142,7 @@
     },
     "to-absolute-glob": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "requires": {
         "extend-shallow": "^2.0.1"
@@ -10150,7 +10150,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -10160,17 +10160,17 @@
     },
     "to-array": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-array/-/to-array-0.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-array/-/to-array-0.1.4.tgz",
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -10178,12 +10178,12 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -10193,12 +10193,12 @@
     },
     "to-readable-stream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
       "integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E="
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-regex/-/to-regex-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "requires": {
         "define-property": "^2.0.2",
@@ -10209,7 +10209,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
         "is-number": "^3.0.0",
@@ -10218,12 +10218,12 @@
     },
     "toidentifier": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/toidentifier/-/toidentifier-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM="
     },
     "tough-cookie": {
       "version": "2.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
       "requires": {
         "psl": "^1.1.24",
@@ -10232,14 +10232,14 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
     },
     "tr46": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tr46/-/tr46-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
         "punycode": "^2.1.0"
@@ -10252,12 +10252,12 @@
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-right/-/trim-right-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "triple-beam": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/triple-beam/-/triple-beam-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha1-pZUhTHKY24M57u7gg+TRC9jLjdk="
     },
     "try-catch": {
@@ -10277,7 +10277,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -10285,12 +10285,12 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -10299,18 +10299,18 @@
     },
     "type-detect": {
       "version": "4.0.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-4.0.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw="
     },
     "type-fest": {
       "version": "0.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.8.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
       "dev": true
     },
     "type-is": {
       "version": "1.6.18",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-is/-/type-is-1.6.18.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
       "requires": {
         "media-typer": "0.3.0",
@@ -10319,17 +10319,17 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typical": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typical/-/typical-4.0.0.tgz",
       "integrity": "sha1-y+r/O5164eK7+vWk5vEezP3pT8Q="
     },
     "ua-parser-js": {
       "version": "0.7.21",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
       "integrity": "sha1-hTz5zpP2QvZxdCc8w0Vlrm8wh3c="
     },
     "uglify-js": {
@@ -10343,17 +10343,17 @@
     },
     "underscore": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/underscore/-/underscore-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/underscore/-/underscore-1.6.0.tgz",
       "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
       "integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg="
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
       "requires": {
         "unicode-canonical-property-names-ecmascript": "^1.0.4",
@@ -10362,17 +10362,17 @@
     },
     "unicode-match-property-value-ecmascript": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
       "integrity": "sha1-W0tCbgjROoA2Xg1lesemwexGonc="
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
       "integrity": "sha1-qcxsx85joKMCP8meNBuUQx1AWlc="
     },
     "union": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/union/-/union-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/union/-/union-0.5.0.tgz",
       "integrity": "sha1-ssEb6E9gU4U3uEbtuboma6AJAHU=",
       "requires": {
         "qs": "^6.4.0"
@@ -10380,7 +10380,7 @@
     },
     "union-value": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/union-value/-/union-value-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "requires": {
         "arr-union": "^3.1.0",
@@ -10391,7 +10391,7 @@
     },
     "unique-stream": {
       "version": "2.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unique-stream/-/unique-stream-2.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unique-stream/-/unique-stream-2.3.1.tgz",
       "integrity": "sha1-xl0RDppK35psWUiygFPZqNBMvqw=",
       "requires": {
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -10400,7 +10400,7 @@
       "dependencies": {
         "through2-filter": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-3.0.0.tgz",
           "integrity": "sha1-cA54bfI2fCyIzYqlvkz5weeDElQ=",
           "requires": {
             "through2": "~2.0.0",
@@ -10419,12 +10419,12 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
         "has-value": "^0.3.1",
@@ -10433,7 +10433,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
             "get-value": "^2.0.3",
@@ -10443,7 +10443,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "requires": {
                 "isarray": "1.0.0"
@@ -10453,14 +10453,14 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
         }
       }
     },
     "untildify": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/untildify/-/untildify-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/untildify/-/untildify-2.1.0.tgz",
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
       "requires": {
         "os-homedir": "^1.0.0"
@@ -10468,7 +10468,7 @@
     },
     "unzip-response": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-1.0.2.tgz",
       "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
     },
     "update-notifier": {
@@ -10490,12 +10490,12 @@
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/upper-case/-/upper-case-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "uri-js": {
       "version": "4.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uri-js/-/uri-js-4.2.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "requires": {
         "punycode": "^2.1.0"
@@ -10503,22 +10503,22 @@
     },
     "urijs": {
       "version": "1.19.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/urijs/-/urijs-1.19.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/urijs/-/urijs-1.19.2.tgz",
       "integrity": "sha1-+b4J8AxMUTS3yzz0dcHdOUUmJlo="
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url-join": {
       "version": "2.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-join/-/url-join-2.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/url-join/-/url-join-2.0.5.tgz",
       "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg="
     },
     "url-parse-lax": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
         "prepend-http": "^1.0.1"
@@ -10526,7 +10526,7 @@
     },
     "url-regex": {
       "version": "5.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-regex/-/url-regex-5.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-regex/-/url-regex-5.0.0.tgz",
       "integrity": "sha1-j1RWq4PYmNGLL5F1OnAmSbhzJzo=",
       "requires": {
         "ip-regex": "^4.1.0",
@@ -10535,19 +10535,19 @@
       "dependencies": {
         "ip-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ip-regex/-/ip-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ip-regex/-/ip-regex-4.1.0.tgz",
           "integrity": "sha1-WtYvaFoU7bQhq+vC//jblN9ntFU="
         }
       }
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/use/-/use-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/use/-/use-3.1.1.tgz",
       "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8="
     },
     "util": {
       "version": "0.12.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/util/-/util-0.12.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/util/-/util-0.12.1.tgz",
       "integrity": "sha1-+QjntjPnOWx2TmlN0U5xYlbOit4=",
       "requires": {
         "inherits": "^2.0.3",
@@ -10559,12 +10559,12 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
@@ -10580,7 +10580,7 @@
     },
     "vali-date": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vali-date/-/vali-date-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vali-date/-/vali-date-1.0.0.tgz",
       "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
     },
     "validate-npm-package-license": {
@@ -10594,7 +10594,7 @@
     },
     "validate-npm-package-name": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "requires": {
         "builtins": "^1.0.3"
@@ -10602,17 +10602,17 @@
     },
     "vargs": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vargs/-/vargs-0.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vargs/-/vargs-0.1.0.tgz",
       "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8="
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -10622,7 +10622,7 @@
     },
     "vinyl": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vinyl/-/vinyl-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vinyl/-/vinyl-1.2.0.tgz",
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "requires": {
         "clone": "^1.0.0",
@@ -10632,14 +10632,14 @@
       "dependencies": {
         "clone": {
           "version": "1.0.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone/-/clone-1.0.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clone/-/clone-1.0.4.tgz",
           "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
         }
       }
     },
     "vinyl-fs": {
       "version": "2.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
       "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
       "requires": {
         "duplexify": "^3.2.0",
@@ -10663,7 +10663,7 @@
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
             "is-utf8": "^0.2.0"
@@ -10673,17 +10673,17 @@
     },
     "vlq": {
       "version": "0.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vlq/-/vlq-0.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vlq/-/vlq-0.2.3.tgz",
       "integrity": "sha1-jz5DKM9jsVQMDWfhsneDhviXWyY="
     },
     "vscode-uri": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vscode-uri/-/vscode-uri-1.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vscode-uri/-/vscode-uri-1.0.6.tgz",
       "integrity": "sha1-a48UGwu8RK17B+lPgvForHYIrU0="
     },
     "wbuf": {
       "version": "1.7.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wbuf/-/wbuf-1.7.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
       "requires": {
         "minimalistic-assert": "^1.0.0"
@@ -10691,7 +10691,7 @@
     },
     "wct-browser-legacy": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-browser-legacy/-/wct-browser-legacy-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wct-browser-legacy/-/wct-browser-legacy-1.0.2.tgz",
       "integrity": "sha1-a+ORdL034pAwKNPb0ikvnE7Fl2c=",
       "requires": {
         "@polymer/polymer": "^3.0.0",
@@ -10710,17 +10710,17 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-1.5.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "browser-stdout": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.0.tgz",
           "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
         },
         "chai": {
           "version": "3.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chai/-/chai-3.5.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chai/-/chai-3.5.0.tgz",
           "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
           "requires": {
             "assertion-error": "^1.0.1",
@@ -10730,7 +10730,7 @@
         },
         "commander": {
           "version": "2.9.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "requires": {
             "graceful-readlink": ">= 1.0.0"
@@ -10738,7 +10738,7 @@
         },
         "debug": {
           "version": "2.6.8",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.8.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "requires": {
             "ms": "2.0.0"
@@ -10746,7 +10746,7 @@
         },
         "deep-eql": {
           "version": "0.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-eql/-/deep-eql-0.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/deep-eql/-/deep-eql-0.1.3.tgz",
           "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
           "requires": {
             "type-detect": "0.1.1"
@@ -10754,19 +10754,19 @@
           "dependencies": {
             "type-detect": {
               "version": "0.1.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-0.1.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-detect/-/type-detect-0.1.1.tgz",
               "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
             }
           }
         },
         "diff": {
           "version": "3.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diff/-/diff-3.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/diff/-/diff-3.2.0.tgz",
           "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
         },
         "glob": {
           "version": "7.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -10779,32 +10779,32 @@
         },
         "growl": {
           "version": "1.9.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/growl/-/growl-1.9.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/growl/-/growl-1.9.2.tgz",
           "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
         },
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "he": {
           "version": "1.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/he/-/he-1.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/he/-/he-1.1.1.tgz",
           "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         },
         "lolex": {
           "version": "1.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lolex/-/lolex-1.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lolex/-/lolex-1.3.2.tgz",
           "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE="
         },
         "mocha": {
           "version": "3.5.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mocha/-/mocha-3.5.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mocha/-/mocha-3.5.3.tgz",
           "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
           "requires": {
             "browser-stdout": "1.3.0",
@@ -10823,7 +10823,7 @@
         },
         "sinon": {
           "version": "1.17.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon/-/sinon-1.17.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sinon/-/sinon-1.17.7.tgz",
           "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
           "requires": {
             "formatio": "1.1.1",
@@ -10834,7 +10834,7 @@
         },
         "supports-color": {
           "version": "3.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-3.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -10842,14 +10842,14 @@
         },
         "type-detect": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-detect/-/type-detect-1.0.0.tgz",
           "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
         }
       }
     },
     "wct-local": {
       "version": "2.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-local/-/wct-local-2.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wct-local/-/wct-local-2.1.5.tgz",
       "integrity": "sha1-95hnU+OtmjXTkXipmJNQUjVh//E=",
       "optional": true,
       "requires": {
@@ -10867,7 +10867,7 @@
     },
     "wct-sauce": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-sauce/-/wct-sauce-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wct-sauce/-/wct-sauce-2.1.0.tgz",
       "integrity": "sha1-Z9C+NGqru8KDhOjRQ7jTynundMA=",
       "optional": true,
       "requires": {
@@ -10896,7 +10896,7 @@
     },
     "web-component-tester": {
       "version": "6.9.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/web-component-tester/-/web-component-tester-6.9.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/web-component-tester/-/web-component-tester-6.9.2.tgz",
       "integrity": "sha1-QKe4JPLPPLxDBVUr38M1eXfe1Io=",
       "requires": {
         "@polymer/sinonjs": "^1.14.1",
@@ -10931,27 +10931,27 @@
       "dependencies": {
         "@polymer/test-fixture": {
           "version": "0.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
           "integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk="
         },
         "@webcomponents/webcomponentsjs": {
           "version": "1.3.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.3.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.3.3.tgz",
           "integrity": "sha1-W7gqDTIQyDa9RiPhOkqTFFy53Cc="
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -10963,7 +10963,7 @@
         },
         "formatio": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/formatio/-/formatio-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/formatio/-/formatio-1.2.0.tgz",
           "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
           "requires": {
             "samsam": "1.x"
@@ -10971,22 +10971,22 @@
         },
         "isarray": {
           "version": "0.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         },
         "lolex": {
           "version": "1.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lolex/-/lolex-1.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lolex/-/lolex-1.6.0.tgz",
           "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY="
         },
         "path-to-regexp": {
           "version": "1.8.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
           "integrity": "sha1-iHs7qdhDk+h6CgufTLdWGYtTVIo=",
           "requires": {
             "isarray": "0.0.1"
@@ -10994,12 +10994,12 @@
         },
         "samsam": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/samsam/-/samsam-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/samsam/-/samsam-1.3.0.tgz",
           "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA="
         },
         "sinon": {
           "version": "2.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon/-/sinon-2.4.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sinon/-/sinon-2.4.1.tgz",
           "integrity": "sha1-Ah/WS1TLd9nS+w1Dze3652KcOjY=",
           "requires": {
             "diff": "^3.1.0",
@@ -11014,7 +11014,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -11022,19 +11022,19 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
     "webidl-conversions": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60="
     },
     "whatwg-url": {
       "version": "6.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-6.5.0.tgz",
       "integrity": "sha1-8t8Cv/F2/WUHDfdK1cy7WhmZZag=",
       "requires": {
         "lodash.sortby": "^4.7.0",
@@ -11052,12 +11052,12 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wide-align": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wide-align/-/wide-align-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
       "requires": {
         "string-width": "^1.0.2 || 2"
@@ -11073,7 +11073,7 @@
     },
     "winston": {
       "version": "3.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/winston/-/winston-3.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/winston/-/winston-3.2.1.tgz",
       "integrity": "sha1-YwYTd5dsc1hAKL4kkKGEYFX3fwc=",
       "requires": {
         "async": "^2.6.1",
@@ -11089,7 +11089,7 @@
       "dependencies": {
         "logform": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/logform/-/logform-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/logform/-/logform-2.1.2.tgz",
           "integrity": "sha1-lXFV6+tnoTFkBpglzmfdtbst02A=",
           "requires": {
             "colors": "^1.2.1",
@@ -11101,7 +11101,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         },
         "readable-stream": {
@@ -11118,7 +11118,7 @@
     },
     "winston-transport": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/winston-transport/-/winston-transport-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/winston-transport/-/winston-transport-4.3.0.tgz",
       "integrity": "sha1-32jAwgJILESNm0cxPAcwTC18LGY=",
       "requires": {
         "readable-stream": "^2.3.6",
@@ -11127,18 +11127,18 @@
     },
     "word-wrap": {
       "version": "1.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/word-wrap/-/word-wrap-1.2.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
       "dev": true
     },
     "wordwrap": {
       "version": "0.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wordwrap/-/wordwrap-0.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wordwrapjs": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
       "integrity": "sha1-yUw3KJTK3G/rGma/9k4dmvksXR4=",
       "requires": {
         "reduce-flatten": "^1.0.1",
@@ -11147,14 +11147,14 @@
       "dependencies": {
         "typical": {
           "version": "2.6.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
           "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
         }
       }
     },
     "wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "requires": {
         "ansi-styles": "^3.2.0",
@@ -11164,12 +11164,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -11179,7 +11179,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -11194,7 +11194,7 @@
     },
     "write": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/write/-/write-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/write/-/write-1.0.3.tgz",
       "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
       "dev": true,
       "requires": {
@@ -11213,7 +11213,7 @@
     },
     "ws": {
       "version": "7.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ws/-/ws-7.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ws/-/ws-7.2.1.tgz",
       "integrity": "sha1-A+1SQjzXRAhLLPQu0ZfItlqTa44="
     },
     "xdg-basedir": {
@@ -11223,7 +11223,7 @@
     },
     "xml2js": {
       "version": "0.4.23",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xml2js/-/xml2js-0.4.23.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xml2js/-/xml2js-0.4.23.tgz",
       "integrity": "sha1-oMaVFnUkIesqx1juTUzPWIQ+rGY=",
       "requires": {
         "sax": ">=0.6.0",
@@ -11232,38 +11232,38 @@
     },
     "xmlbuilder": {
       "version": "11.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha1-vpuuHIoEbnazESdyY0fQrXACvrM="
     },
     "xmldom": {
       "version": "0.1.31",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmldom/-/xmldom-0.1.31.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xmldom/-/xmldom-0.1.31.tgz",
       "integrity": "sha1-t2yaG9nwqXN+WnLcNyMc84N14v8=",
       "optional": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xtend/-/xtend-4.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
     },
     "y18n": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/y18n/-/y18n-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms="
     },
     "yallist": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yallist/-/yallist-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0="
     },
     "yaml": {
       "version": "1.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yaml/-/yaml-1.7.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yaml/-/yaml-1.7.2.tgz",
       "integrity": "sha1-8mqr9zhZCrYe+spQI1jkjcnzSLI=",
       "requires": {
         "@babel/runtime": "^7.6.3"
@@ -11271,7 +11271,7 @@
     },
     "yargs": {
       "version": "15.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs/-/yargs-15.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs/-/yargs-15.0.2.tgz",
       "integrity": "sha1-Qki/IY7wUDhcT34U699CVlPRO9M=",
       "requires": {
         "cliui": "^6.0.0",
@@ -11289,12 +11289,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
         },
         "ansi-styles": {
           "version": "4.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
           "requires": {
             "@types/color-name": "^1.1.1",
@@ -11303,7 +11303,7 @@
         },
         "cliui": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cliui/-/cliui-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cliui/-/cliui-6.0.0.tgz",
           "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
           "requires": {
             "string-width": "^4.2.0",
@@ -11313,7 +11313,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "requires": {
             "color-name": "~1.1.4"
@@ -11321,17 +11321,17 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
         },
         "find-up": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
           "requires": {
             "locate-path": "^5.0.0",
@@ -11340,12 +11340,12 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
           "requires": {
             "p-locate": "^4.1.0"
@@ -11353,7 +11353,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
           "requires": {
             "p-limit": "^2.2.0"
@@ -11361,12 +11361,12 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM="
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -11376,7 +11376,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "requires": {
             "ansi-regex": "^5.0.0"
@@ -11384,7 +11384,7 @@
         },
         "wrap-ansi": {
           "version": "6.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
           "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -11394,7 +11394,7 @@
         },
         "yargs-parser": {
           "version": "16.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-16.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-16.1.0.tgz",
           "integrity": "sha1-c3R9U64YfnuNvjM/lXFMduoA7PE=",
           "requires": {
             "camelcase": "^5.0.0",
@@ -11405,7 +11405,7 @@
     },
     "yargs-parser": {
       "version": "13.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-13.1.1.tgz",
       "integrity": "sha1-0mBYUyqgbTZf4JH2ofwGsvfl7KA=",
       "requires": {
         "camelcase": "^5.0.0",
@@ -11414,7 +11414,7 @@
     },
     "yargs-unparser": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
       "integrity": "sha1-7yXCx2n/a9CeSw+dfGBfsnhG6p8=",
       "requires": {
         "flat": "^4.1.0",
@@ -11424,12 +11424,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -11439,7 +11439,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -11447,7 +11447,7 @@
         },
         "yargs": {
           "version": "13.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs/-/yargs-13.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs/-/yargs-13.3.0.tgz",
           "integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
           "requires": {
             "cliui": "^5.0.0",
@@ -11466,7 +11466,7 @@
     },
     "yauzl": {
       "version": "2.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yauzl/-/yauzl-2.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "requires": {
         "fd-slicer": "~1.0.1"
@@ -11474,7 +11474,7 @@
     },
     "yeast": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yeast/-/yeast-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
     },
     "zip-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -633,7 +633,7 @@
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
       "integrity": "sha1-7N9I1TLFjqR3rPyrgDSEJPjQZi8=",
       "requires": {
         "any-observable": "^0.3.0"
@@ -641,7 +641,7 @@
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sindresorhus/is/-/is-0.14.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o="
     },
     "@sinonjs/commons": {
@@ -678,7 +678,7 @@
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
       "integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
       "requires": {
         "defer-to-connect": "^1.0.1"
@@ -1094,7 +1094,7 @@
     },
     "ajv": {
       "version": "6.10.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ajv/-/ajv-6.10.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -1105,7 +1105,7 @@
     },
     "ansi-align": {
       "version": "2.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-2.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "requires": {
         "string-width": "^2.0.0"
@@ -1128,7 +1128,7 @@
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "requires": {
         "color-convert": "^1.9.0"
@@ -1136,13 +1136,29 @@
     },
     "any-observable": {
       "version": "0.3.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/any-observable/-/any-observable-0.3.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/any-observable/-/any-observable-0.3.0.tgz",
       "integrity": "sha1-r5M0deWAamfQ198JDdXovvZdEZs="
     },
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+    },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
+        }
+      }
     },
     "append-field": {
       "version": "1.0.0",
@@ -1221,7 +1237,7 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -1249,7 +1265,7 @@
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-flatten": {
@@ -1264,7 +1280,7 @@
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
         "array-uniq": "^1.0.1"
@@ -1272,7 +1288,7 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
@@ -1287,7 +1303,7 @@
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1": {
@@ -1315,7 +1331,7 @@
     },
     "astral-regex": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/astral-regex/-/astral-regex-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
       "dev": true
     },
@@ -1730,7 +1746,7 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
@@ -1819,6 +1835,11 @@
         "callsite": "1.0.0"
       }
     },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w="
+    },
     "bl": {
       "version": "2.2.0",
       "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bl/-/bl-2.2.0.tgz",
@@ -1877,7 +1898,7 @@
     },
     "boxen": {
       "version": "1.3.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/boxen/-/boxen-1.3.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
       "requires": {
         "ansi-align": "^2.0.0",
@@ -1891,14 +1912,14 @@
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         }
       }
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
         "balanced-match": "^1.0.0",
@@ -2003,7 +2024,7 @@
     },
     "builtins": {
       "version": "1.0.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/builtins/-/builtins-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
     },
     "busboy": {
@@ -2061,7 +2082,7 @@
     },
     "cacheable-request": {
       "version": "6.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cacheable-request/-/cacheable-request-6.1.0.tgz",
       "integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
       "requires": {
         "clone-response": "^1.0.2",
@@ -2075,7 +2096,7 @@
       "dependencies": {
         "get-stream": {
           "version": "5.1.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-5.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-5.1.0.tgz",
           "integrity": "sha1-ASA83JJZf5uQkGfD5lbMH008Tck=",
           "requires": {
             "pump": "^3.0.0"
@@ -2083,7 +2104,7 @@
         },
         "lowercase-keys": {
           "version": "2.0.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
           "integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk="
         }
       }
@@ -2095,7 +2116,7 @@
     },
     "callsites": {
       "version": "3.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/callsites/-/callsites-3.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
       "dev": true
     },
@@ -2110,12 +2131,12 @@
     },
     "camelcase": {
       "version": "5.3.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase/-/camelcase-5.3.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
     },
     "camelcase-keys": {
       "version": "4.2.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "requires": {
         "camelcase": "^4.1.0",
@@ -2125,7 +2146,7 @@
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         }
       }
@@ -2147,7 +2168,7 @@
     },
     "capture-stack-trace": {
       "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
       "integrity": "sha1-psC74fOPOqC5Ijjstv9Cw0TUE10="
     },
     "caseless": {
@@ -2178,7 +2199,7 @@
     },
     "chalk": {
       "version": "2.4.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "requires": {
         "ansi-styles": "^3.2.1",
@@ -2198,7 +2219,7 @@
     },
     "chardet": {
       "version": "0.7.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chardet/-/chardet-0.7.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4="
     },
     "charenc": {
@@ -2210,6 +2231,73 @@
       "version": "1.0.2",
       "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+    },
+    "chokidar": {
+      "version": "3.3.1",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chokidar/-/chokidar-3.3.1.tgz",
+      "integrity": "sha1-yE5bPRjZpNd1WP70ZrG/FrvrNFA=",
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.3.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.0",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-5.1.0.tgz",
+          "integrity": "sha1-X0wdHnSNMM1zrSlEs1d6gbCB6MI=",
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
     },
     "chownr": {
       "version": "1.1.3",
@@ -2230,7 +2318,7 @@
     },
     "ci-info": {
       "version": "1.6.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ci-info/-/ci-info-1.6.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ci-info/-/ci-info-1.6.0.tgz",
       "integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc="
     },
     "class-utils": {
@@ -2269,7 +2357,7 @@
     },
     "cli-boxes": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
     },
     "cli-cursor": {
@@ -2282,7 +2370,7 @@
     },
     "cli-truncate": {
       "version": "0.2.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-truncate/-/cli-truncate-0.2.1.tgz",
       "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
       "requires": {
         "slice-ansi": "0.0.4",
@@ -2291,12 +2379,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -2304,7 +2392,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -2314,7 +2402,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -2324,12 +2412,12 @@
     },
     "cli-width": {
       "version": "2.2.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-width/-/cli-width-2.2.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "clipboard": {
       "version": "2.0.4",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clipboard/-/clipboard-2.0.4.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clipboard/-/clipboard-2.0.4.tgz",
       "integrity": "sha1-g22v1mzw/qXXHOXVsL9ulYAJES0=",
       "optional": true,
       "requires": {
@@ -2340,7 +2428,7 @@
     },
     "cliui": {
       "version": "5.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cliui/-/cliui-5.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
       "requires": {
         "string-width": "^3.1.0",
@@ -2380,7 +2468,7 @@
     },
     "clone-response": {
       "version": "1.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clone-response/-/clone-response-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "requires": {
         "mimic-response": "^1.0.0"
@@ -2393,7 +2481,7 @@
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-visit": {
@@ -2416,7 +2504,7 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-1.9.3.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "requires": {
         "color-name": "1.1.3"
@@ -2424,7 +2512,7 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
@@ -2569,7 +2657,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
@@ -2585,7 +2673,7 @@
     },
     "configstore": {
       "version": "3.1.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/configstore/-/configstore-3.1.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha1-xvJd767vJt8S3TNBSwAf6BpUP48=",
       "requires": {
         "dot-prop": "^4.1.0",
@@ -2634,7 +2722,7 @@
     },
     "copyfiles": {
       "version": "2.1.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/copyfiles/-/copyfiles-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/copyfiles/-/copyfiles-2.1.1.tgz",
       "integrity": "sha1-1DDhIteID5LEXTciCLCvA7DDnbY=",
       "dev": true,
       "requires": {
@@ -2699,7 +2787,7 @@
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
@@ -2747,7 +2835,7 @@
     },
     "create-error-class": {
       "version": "3.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/create-error-class/-/create-error-class-3.0.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
         "capture-stack-trace": "^1.0.0"
@@ -2755,7 +2843,7 @@
     },
     "cross-spawn": {
       "version": "6.0.5",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
       "requires": {
         "nice-try": "^1.0.4",
@@ -2772,7 +2860,7 @@
     },
     "crypto-random-string": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
     "css-b64-images": {
@@ -2799,7 +2887,7 @@
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "requires": {
         "array-find-index": "^1.0.1"
@@ -2815,7 +2903,7 @@
     },
     "date-fns": {
       "version": "1.30.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/date-fns/-/date-fns-1.30.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha1-LnG/CxGRU9u0zE6I2epaz7UNwFw="
     },
     "debug": {
@@ -2828,12 +2916,12 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "requires": {
         "decamelize": "^1.1.0",
@@ -2842,7 +2930,7 @@
       "dependencies": {
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         }
       }
@@ -2854,7 +2942,7 @@
     },
     "decompress-response": {
       "version": "3.3.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decompress-response/-/decompress-response-3.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
         "mimic-response": "^1.0.0"
@@ -2870,17 +2958,17 @@
     },
     "deep-extend": {
       "version": "0.6.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/deep-extend/-/deep-extend-0.6.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw="
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "defer-to-connect": {
       "version": "1.1.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
       "integrity": "sha1-iK5pS5P2e4GBWiyMdprvZXSsjy8="
     },
     "define-properties": {
@@ -2949,7 +3037,7 @@
     },
     "delegate": {
       "version": "3.2.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/delegate/-/delegate-3.2.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha1-tmtxwxWFIuirV0T3INjKDCr1kWY=",
       "optional": true
     },
@@ -3056,7 +3144,7 @@
     },
     "dot-prop": {
       "version": "4.2.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-4.2.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
       "requires": {
         "is-obj": "^1.0.0"
@@ -3072,7 +3160,7 @@
     },
     "duplexer3": {
       "version": "0.1.4",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/duplexer3/-/duplexer3-0.1.4.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "duplexify": {
@@ -3120,7 +3208,7 @@
     },
     "elegant-spinner": {
       "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
     },
     "emitter-component": {
@@ -3130,7 +3218,7 @@
     },
     "emoji-regex": {
       "version": "7.0.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY="
     },
     "enabled": {
@@ -3148,7 +3236,7 @@
     },
     "end-of-stream": {
       "version": "1.4.4",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
       "requires": {
         "once": "^1.4.0"
@@ -3252,7 +3340,7 @@
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -3306,7 +3394,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
@@ -3580,7 +3668,7 @@
     },
     "eslint-scope": {
       "version": "5.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-scope/-/eslint-scope-5.0.0.tgz",
       "integrity": "sha1-6HyIh8c+jR7ITxylkWRcNYv8j7k=",
       "dev": true,
       "requires": {
@@ -3590,7 +3678,7 @@
     },
     "eslint-utils": {
       "version": "1.4.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-utils/-/eslint-utils-1.4.3.tgz",
       "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
       "dev": true,
       "requires": {
@@ -3599,7 +3687,7 @@
     },
     "eslint-visitor-keys": {
       "version": "1.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
       "integrity": "sha1-4qgs6oT/JGrW+1f5veW0ZiFFnsI=",
       "dev": true
     },
@@ -3614,12 +3702,12 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/esprima/-/esprima-4.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
     },
     "esquery": {
       "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/esquery/-/esquery-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esquery/-/esquery-1.0.1.tgz",
       "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
       "dev": true,
       "requires": {
@@ -3628,7 +3716,7 @@
     },
     "esrecurse": {
       "version": "4.2.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/esrecurse/-/esrecurse-4.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "dev": true,
       "requires": {
@@ -3637,13 +3725,13 @@
     },
     "estraverse": {
       "version": "4.3.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/estraverse/-/estraverse-4.3.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/esutils/-/esutils-2.0.3.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q="
     },
     "etag": {
@@ -3861,7 +3949,7 @@
     },
     "external-editor": {
       "version": "3.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/external-editor/-/external-editor-3.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
       "requires": {
         "chardet": "^0.7.0",
@@ -3946,7 +4034,7 @@
     },
     "fast-deep-equal": {
       "version": "2.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
@@ -3956,7 +4044,7 @@
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
@@ -4002,7 +4090,7 @@
     },
     "file-entry-cache": {
       "version": "5.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
       "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
       "dev": true,
       "requires": {
@@ -4074,7 +4162,7 @@
     },
     "find-up": {
       "version": "3.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "requires": {
         "locate-path": "^3.0.0"
@@ -4106,7 +4194,7 @@
     },
     "flat-cache": {
       "version": "2.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/flat-cache/-/flat-cache-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/flat-cache/-/flat-cache-2.0.1.tgz",
       "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
       "dev": true,
       "requires": {
@@ -4128,7 +4216,7 @@
     },
     "flatted": {
       "version": "2.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/flatted/-/flatted-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha1-aeV8qo8OrLwoHS4stFjUb9tEngg=",
       "dev": true
     },
@@ -4235,8 +4323,14 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "2.1.2",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fsevents/-/fsevents-2.1.2.tgz",
+      "integrity": "sha1-TAofs0vGjlQ7S4Kp7Dkr+9qECAU=",
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -4245,7 +4339,7 @@
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
@@ -4268,7 +4362,7 @@
     },
     "get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
     },
     "get-func-name": {
@@ -4304,12 +4398,12 @@
     },
     "github-url-from-git": {
       "version": "1.5.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
       "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA="
     },
     "glob": {
       "version": "7.1.6",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob/-/glob-7.1.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.6.tgz",
       "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -4529,7 +4623,7 @@
     },
     "global-dirs": {
       "version": "0.1.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-0.1.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "requires": {
         "ini": "^1.3.4"
@@ -4564,7 +4658,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globby/-/globby-6.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "requires": {
         "array-union": "^1.0.1",
@@ -4576,14 +4670,14 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
     "good-listener": {
       "version": "1.2.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/good-listener/-/good-listener-1.2.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "optional": true,
       "requires": {
@@ -4615,7 +4709,7 @@
     },
     "graceful-fs": {
       "version": "4.2.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha1-ShL/G2A3bvCYYsIJPt2Qgyi+hCM="
     },
     "graceful-readlink": {
@@ -4697,7 +4791,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -4705,7 +4799,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         }
       }
@@ -4737,7 +4831,7 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
@@ -4781,7 +4875,7 @@
     },
     "has-yarn": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-yarn/-/has-yarn-1.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-yarn/-/has-yarn-1.0.0.tgz",
       "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac="
     },
     "he": {
@@ -4799,7 +4893,7 @@
     },
     "hosted-git-info": {
       "version": "2.8.5",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
       "integrity": "sha1-dZz88sTRVq3lmwst+r3cQqa5xww="
     },
     "hpack.js": {
@@ -4829,7 +4923,7 @@
     },
     "http-cache-semantics": {
       "version": "4.0.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
       "integrity": "sha1-SVcEdzJ37u9uQ/mrLCx9JZ3aJcU="
     },
     "http-deceiver": {
@@ -5019,7 +5113,7 @@
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -5032,7 +5126,7 @@
     },
     "ignore": {
       "version": "4.0.6",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ignore/-/ignore-4.0.6.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
       "dev": true
     },
@@ -5043,7 +5137,7 @@
     },
     "import-fresh": {
       "version": "3.2.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/import-fresh/-/import-fresh-3.2.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/import-fresh/-/import-fresh-3.2.1.tgz",
       "integrity": "sha1-Yz/2GFBueTr1rJG/SLcmd+FcvmY=",
       "dev": true,
       "requires": {
@@ -5053,12 +5147,12 @@
     },
     "import-lazy": {
       "version": "2.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/import-lazy/-/import-lazy-2.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/import-lazy/-/import-lazy-2.1.0.tgz",
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent": {
@@ -5068,7 +5162,7 @@
     },
     "indent-string": {
       "version": "3.2.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/indent-string/-/indent-string-3.2.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent-string/-/indent-string-3.2.0.tgz",
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
     },
     "indexof": {
@@ -5078,7 +5172,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
@@ -5087,12 +5181,12 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ini/-/ini-1.3.5.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ini/-/ini-1.3.5.tgz",
       "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
     },
     "inquirer": {
@@ -5183,8 +5277,16 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
     },
     "is-buffer": {
       "version": "2.0.4",
@@ -5198,7 +5300,7 @@
     },
     "is-ci": {
       "version": "1.2.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-ci/-/is-ci-1.2.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-ci/-/is-ci-1.2.1.tgz",
       "integrity": "sha1-43ecjuF/zPQoSI9uKBGH8uYyhBw=",
       "requires": {
         "ci-info": "^1.5.0"
@@ -5269,7 +5371,7 @@
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-finite": {
@@ -5282,7 +5384,7 @@
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-generator-function": {
@@ -5300,7 +5402,7 @@
     },
     "is-installed-globally": {
       "version": "0.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "requires": {
         "global-dirs": "^0.1.0",
@@ -5319,7 +5421,7 @@
     },
     "is-npm": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-npm/-/is-npm-1.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-npm/-/is-npm-1.0.0.tgz",
       "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
     },
     "is-number": {
@@ -5347,12 +5449,12 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-observable": {
       "version": "1.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-observable/-/is-observable-1.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-observable/-/is-observable-1.1.0.tgz",
       "integrity": "sha1-s+mGyPRN6VCGfKtUA/WjRlAFl14=",
       "requires": {
         "symbol-observable": "^1.1.0"
@@ -5381,7 +5483,7 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
@@ -5404,12 +5506,12 @@
     },
     "is-promise": {
       "version": "2.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-promise/-/is-promise-2.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-redirect": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-redirect/-/is-redirect-1.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
     "is-regex": {
@@ -5422,12 +5524,12 @@
     },
     "is-retry-allowed": {
       "version": "1.2.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
       "integrity": "sha1-13hIi9CkZmo76KFIK58rqv7eqLQ="
     },
     "is-scoped": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-scoped/-/is-scoped-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-scoped/-/is-scoped-1.0.0.tgz",
       "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
       "requires": {
         "scoped-regex": "^1.0.0"
@@ -5435,7 +5537,7 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
@@ -5458,7 +5560,7 @@
     },
     "is-url-superb": {
       "version": "3.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-url-superb/-/is-url-superb-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-url-superb/-/is-url-superb-3.0.0.tgz",
       "integrity": "sha1-uaHah4oaxzZZBH0eb07yLCCdPiU=",
       "requires": {
         "url-regex": "^5.0.0"
@@ -5501,7 +5603,7 @@
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
@@ -5516,17 +5618,17 @@
     },
     "issue-regex": {
       "version": "2.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/issue-regex/-/issue-regex-2.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/issue-regex/-/issue-regex-2.0.0.tgz",
       "integrity": "sha1-uxgCSQOU+Ag8emeHJHy/l1Y4710="
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
     },
     "js-yaml": {
       "version": "3.13.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/js-yaml/-/js-yaml-3.13.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
       "requires": {
         "argparse": "^1.0.7",
@@ -5545,12 +5647,12 @@
     },
     "json-buffer": {
       "version": "3.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-buffer/-/json-buffer-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk="
     },
     "json-schema": {
@@ -5560,12 +5662,12 @@
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "json-stringify-safe": {
@@ -5627,7 +5729,7 @@
     },
     "keyv": {
       "version": "3.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/keyv/-/keyv-3.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/keyv/-/keyv-3.1.0.tgz",
       "integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
       "requires": {
         "json-buffer": "3.0.0"
@@ -5648,7 +5750,7 @@
     },
     "latest-version": {
       "version": "3.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/latest-version/-/latest-version-3.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "requires": {
         "package-json": "^4.0.0"
@@ -5705,7 +5807,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/levn/-/levn-0.3.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -5723,7 +5825,7 @@
     },
     "listr": {
       "version": "0.14.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr/-/listr-0.14.3.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr/-/listr-0.14.3.tgz",
       "integrity": "sha1-L+qQlgTkNL5GTFC926DUlpKPpYY=",
       "requires": {
         "@samverschueren/stream-to-observable": "^0.3.0",
@@ -5739,7 +5841,7 @@
     },
     "listr-input": {
       "version": "0.1.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr-input/-/listr-input-0.1.3.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-input/-/listr-input-0.1.3.tgz",
       "integrity": "sha1-DDE5Z7bReevpZKgek2POKlo50lw=",
       "requires": {
         "inquirer": "^3.3.0",
@@ -5749,12 +5851,12 @@
       "dependencies": {
         "chardet": {
           "version": "0.4.2",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chardet/-/chardet-0.4.2.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chardet/-/chardet-0.4.2.tgz",
           "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha1-BFURz9jRM/OEZnPRBHwVTiFK09U=",
           "requires": {
             "chardet": "^0.4.0",
@@ -5764,7 +5866,7 @@
         },
         "inquirer": {
           "version": "3.3.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inquirer/-/inquirer-3.3.0.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer/-/inquirer-3.3.0.tgz",
           "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
           "requires": {
             "ansi-escapes": "^3.0.0",
@@ -5785,7 +5887,7 @@
         },
         "rxjs": {
           "version": "5.5.12",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rxjs/-/rxjs-5.5.12.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rxjs/-/rxjs-5.5.12.tgz",
           "integrity": "sha1-b6YbinfD15PbrycL7i9D9lLXQcw=",
           "requires": {
             "symbol-observable": "1.0.1"
@@ -5800,12 +5902,12 @@
     },
     "listr-silent-renderer": {
       "version": "1.1.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
       "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
     },
     "listr-update-renderer": {
       "version": "0.5.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
       "integrity": "sha1-Tqg2hUinuK7LfgbYyVy0WuLt5qI=",
       "requires": {
         "chalk": "^1.1.3",
@@ -5820,17 +5922,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -5842,7 +5944,7 @@
         },
         "figures": {
           "version": "1.7.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/figures/-/figures-1.7.0.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-1.7.0.tgz",
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "requires": {
             "escape-string-regexp": "^1.0.5",
@@ -5851,7 +5953,7 @@
         },
         "log-symbols": {
           "version": "1.0.2",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-1.0.2.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-1.0.2.tgz",
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "requires": {
             "chalk": "^1.0.0"
@@ -5859,7 +5961,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -5867,14 +5969,14 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
     "listr-verbose-renderer": {
       "version": "0.5.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
       "integrity": "sha1-8RMhZ1NepMEmEQK58o2sfLoeA9s=",
       "requires": {
         "chalk": "^2.4.1",
@@ -5885,7 +5987,7 @@
     },
     "load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/load-json-file/-/load-json-file-4.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -5912,7 +6014,7 @@
     },
     "locate-path": {
       "version": "3.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/locate-path/-/locate-path-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "requires": {
         "p-locate": "^3.0.0",
@@ -5921,7 +6023,7 @@
     },
     "lodash": {
       "version": "4.17.15",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash/-/lodash-4.17.15.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg="
     },
     "lodash._baseassign": {
@@ -6052,12 +6154,12 @@
     },
     "lodash.zip": {
       "version": "4.2.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.zip/-/lodash.zip-4.2.0.tgz",
       "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA="
     },
     "log-symbols": {
       "version": "2.2.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-2.2.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
       "requires": {
         "chalk": "^2.0.1"
@@ -6065,7 +6167,7 @@
     },
     "log-update": {
       "version": "2.3.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/log-update/-/log-update-2.3.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-update/-/log-update-2.3.0.tgz",
       "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -6075,7 +6177,7 @@
       "dependencies": {
         "wrap-ansi": {
           "version": "3.0.1",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
           "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
           "requires": {
             "string-width": "^2.1.1",
@@ -6118,7 +6220,7 @@
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "requires": {
         "currently-unhandled": "^0.4.1",
@@ -6132,12 +6234,12 @@
     },
     "lowercase-keys": {
       "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
     },
     "lru-cache": {
       "version": "4.1.5",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
       "requires": {
         "pseudomap": "^1.0.2",
@@ -6161,7 +6263,7 @@
     },
     "make-dir": {
       "version": "1.3.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/make-dir/-/make-dir-1.3.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
       "requires": {
         "pify": "^3.0.0"
@@ -6189,7 +6291,7 @@
     },
     "map-obj": {
       "version": "2.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-obj/-/map-obj-2.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-2.0.0.tgz",
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
     },
     "map-visit": {
@@ -6254,7 +6356,7 @@
     },
     "meow": {
       "version": "5.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/meow/-/meow-5.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/meow/-/meow-5.0.0.tgz",
       "integrity": "sha1-38c9Y6mvxxSl43F2DrXIi5EHiqQ=",
       "requires": {
         "camelcase-keys": "^4.0.0",
@@ -6270,7 +6372,7 @@
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "find-up": {
@@ -6322,7 +6424,7 @@
         },
         "yargs-parser": {
           "version": "10.1.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-10.1.0.tgz",
           "integrity": "sha1-cgImW4n36eny5XZeD+c1qQXtuqg=",
           "requires": {
             "camelcase": "^4.1.0"
@@ -6393,7 +6495,7 @@
     },
     "mimic-response": {
       "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-response/-/mimic-response-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs="
     },
     "minify": {
@@ -6432,7 +6534,7 @@
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimatch/-/minimatch-3.0.4.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -6448,12 +6550,12 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minimist-options": {
       "version": "3.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist-options/-/minimist-options-3.0.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist-options/-/minimist-options-3.0.2.tgz",
       "integrity": "sha1-+6TIGRM54T7PTWG+sD8HAQPz2VQ=",
       "requires": {
         "arrify": "^1.0.1",
@@ -6498,7 +6600,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -6676,7 +6778,7 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
@@ -6687,7 +6789,7 @@
     },
     "nice-try": {
       "version": "1.0.5",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nice-try/-/nice-try-1.0.5.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y="
     },
     "nise": {
@@ -6780,7 +6882,7 @@
     },
     "noms": {
       "version": "0.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/noms/-/noms-0.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/noms/-/noms-0.0.0.tgz",
       "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
       "dev": true,
       "requires": {
@@ -6816,7 +6918,7 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -6835,7 +6937,7 @@
     },
     "normalize-url": {
       "version": "4.5.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-url/-/normalize-url-4.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha1-RTNUCH5sqWlXvY9br3U/WYIUISk="
     },
     "np": {
@@ -6921,7 +7023,7 @@
     },
     "npm-name": {
       "version": "5.5.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/npm-name/-/npm-name-5.5.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-name/-/npm-name-5.5.0.tgz",
       "integrity": "sha1-OnOtvLBIikGkT/gg7VHcwyxyvQk=",
       "requires": {
         "got": "^9.6.0",
@@ -6953,7 +7055,7 @@
         },
         "is-scoped": {
           "version": "2.1.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-scoped/-/is-scoped-2.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-scoped/-/is-scoped-2.1.0.tgz",
           "integrity": "sha1-/vBxN3Jli99b7kGGCCZ92ubTVm0=",
           "requires": {
             "scoped-regex": "^2.0.0"
@@ -6966,7 +7068,7 @@
         },
         "scoped-regex": {
           "version": "2.1.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/scoped-regex/-/scoped-regex-2.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/scoped-regex/-/scoped-regex-2.1.0.tgz",
           "integrity": "sha1-e5voRdgf2dIdHsl8YaC3z4bSAV8="
         },
         "url-parse-lax": {
@@ -6981,7 +7083,7 @@
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
         "path-key": "^2.0.0"
@@ -6989,7 +7091,7 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
@@ -6999,7 +7101,7 @@
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-component": {
@@ -7126,7 +7228,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/once/-/once-1.4.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
@@ -7169,7 +7271,7 @@
     },
     "optionator": {
       "version": "0.8.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/optionator/-/optionator-0.8.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
       "dev": true,
       "requires": {
@@ -7207,7 +7309,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
@@ -7226,7 +7328,7 @@
     },
     "p-cancelable": {
       "version": "1.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-cancelable/-/p-cancelable-1.1.0.tgz",
       "integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw="
     },
     "p-defer": {
@@ -7236,7 +7338,7 @@
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
@@ -7254,7 +7356,7 @@
     },
     "p-locate": {
       "version": "3.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-locate/-/p-locate-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "requires": {
         "p-limit": "^2.0.0"
@@ -7276,7 +7378,7 @@
     },
     "p-timeout": {
       "version": "2.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-timeout/-/p-timeout-2.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-timeout/-/p-timeout-2.0.1.tgz",
       "integrity": "sha1-2N0ZeVldLcATnh/ka4tkbLPN8Dg=",
       "requires": {
         "p-finally": "^1.0.0"
@@ -7284,12 +7386,12 @@
     },
     "p-try": {
       "version": "2.2.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
     },
     "package-json": {
       "version": "4.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/package-json/-/package-json-4.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "requires": {
         "got": "^6.7.1",
@@ -7305,7 +7407,7 @@
         },
         "got": {
           "version": "6.7.1",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/got/-/got-6.7.1.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "requires": {
             "create-error-class": "^3.0.0",
@@ -7323,7 +7425,7 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
           "integrity": "sha1-10RoFUM/XV7WQxzV3KIQSPZrOX4=",
           "requires": {
             "rc": "^1.1.6",
@@ -7332,7 +7434,7 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-url/-/registry-url-3.1.0.tgz",
+          "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-url/-/registry-url-3.1.0.tgz",
           "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "requires": {
             "rc": "^1.0.1"
@@ -7365,7 +7467,7 @@
     },
     "parent-module": {
       "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parent-module/-/parent-module-1.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
       "dev": true,
       "requires": {
@@ -7449,27 +7551,27 @@
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-parse/-/path-parse-1.0.6.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw="
     },
     "path-to-regexp": {
@@ -7479,7 +7581,7 @@
     },
     "path-type": {
       "version": "3.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-type/-/path-type-3.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
       "requires": {
         "pify": "^3.0.0"
@@ -7525,6 +7627,11 @@
       "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "picomatch": {
+      "version": "2.2.1",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/picomatch/-/picomatch-2.2.1.tgz",
+      "integrity": "sha1-IbrIiLbthgH4Mc54FuM1vHefCko="
+    },
     "pify": {
       "version": "4.0.1",
       "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-4.0.1.tgz",
@@ -7532,12 +7639,12 @@
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
         "pinkie": "^2.0.0"
@@ -7918,7 +8025,7 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
@@ -7939,7 +8046,7 @@
     },
     "prismjs": {
       "version": "1.17.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prismjs/-/prismjs-1.17.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prismjs/-/prismjs-1.17.1.tgz",
       "integrity": "sha1-5mn8vUzdhzw1ECiBwzsU0NaFGb4=",
       "requires": {
         "clipboard": "^2.0.0"
@@ -7952,12 +8059,12 @@
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/progress/-/progress-2.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/progress/-/progress-2.0.3.tgz",
       "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg="
     },
     "proxy-addr": {
@@ -7971,7 +8078,7 @@
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
@@ -7981,7 +8088,7 @@
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pump/-/pump-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pump/-/pump-3.0.0.tgz",
       "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -7990,7 +8097,7 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
     },
     "q": {
@@ -8010,7 +8117,7 @@
     },
     "quick-lru": {
       "version": "1.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/quick-lru/-/quick-lru-1.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/quick-lru/-/quick-lru-1.1.0.tgz",
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
     },
     "randomatic": {
@@ -8048,7 +8155,7 @@
     },
     "rc": {
       "version": "1.2.8",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rc/-/rc-1.2.8.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rc/-/rc-1.2.8.tgz",
       "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
       "requires": {
         "deep-extend": "^0.6.0",
@@ -8059,7 +8166,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -8075,7 +8182,7 @@
     },
     "read-pkg": {
       "version": "3.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-3.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "requires": {
         "load-json-file": "^4.0.0",
@@ -8106,9 +8213,17 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "readdirp": {
+      "version": "3.3.0",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readdirp/-/readdirp-3.3.0.tgz",
+      "integrity": "sha1-mERY0ToeQuLp9YQbEp4WLzaa/xc=",
+      "requires": {
+        "picomatch": "^2.0.7"
+      }
+    },
     "redent": {
       "version": "2.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/redent/-/redent-2.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/redent/-/redent-2.0.0.tgz",
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "requires": {
         "indent-string": "^3.0.0",
@@ -8165,7 +8280,7 @@
     },
     "regexpp": {
       "version": "2.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regexpp/-/regexpp-2.0.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
       "dev": true
     },
@@ -8184,7 +8299,7 @@
     },
     "registry-auth-token": {
       "version": "4.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
       "integrity": "sha1-MOVZYe7Hc3naVR6lxM9Dy/A1Ir4=",
       "requires": {
         "rc": "^1.2.8",
@@ -8193,7 +8308,7 @@
     },
     "registry-url": {
       "version": "5.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-url/-/registry-url-5.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-url/-/registry-url-5.1.0.tgz",
       "integrity": "sha1-6YM0tQ1UNLgRNrROxjjZwgCcUAk=",
       "requires": {
         "rc": "^1.2.8"
@@ -8388,12 +8503,12 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs="
     },
     "requirejs": {
@@ -8425,7 +8540,7 @@
     },
     "resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/resolve-from/-/resolve-from-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
       "dev": true
     },
@@ -8436,7 +8551,7 @@
     },
     "responselike": {
       "version": "1.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/responselike/-/responselike-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/responselike/-/responselike-1.0.2.tgz",
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "requires": {
         "lowercase-keys": "^1.0.0"
@@ -8483,7 +8598,7 @@
     },
     "run-async": {
       "version": "2.3.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/run-async/-/run-async-2.3.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
         "is-promise": "^2.1.0"
@@ -8491,12 +8606,12 @@
     },
     "rx-lite": {
       "version": "4.0.8",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rx-lite/-/rx-lite-4.0.8.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "requires": {
         "rx-lite": "*"
@@ -8512,7 +8627,7 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "safe-regex": {
@@ -8525,13 +8640,21 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "samsam": {
       "version": "1.1.2",
       "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/samsam/-/samsam-1.1.2.tgz",
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
+    },
+    "sass": {
+      "version": "1.24.4",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sass/-/sass-1.24.4.tgz",
+      "integrity": "sha1-qlBXWp7SuelkW1WZFW/RSb2tnqo=",
+      "requires": {
+        "chokidar": ">=2.0.0 <4.0.0"
+      }
     },
     "sauce-connect-launcher": {
       "version": "1.3.1",
@@ -8553,7 +8676,7 @@
     },
     "scoped-regex": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/scoped-regex/-/scoped-regex-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/scoped-regex/-/scoped-regex-1.0.0.tgz",
       "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
     },
     "secure-compare": {
@@ -8563,7 +8686,7 @@
     },
     "select": {
       "version": "1.1.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/select/-/select-1.1.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
       "optional": true
     },
@@ -8663,7 +8786,7 @@
     },
     "semver-diff": {
       "version": "2.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-2.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
         "semver": "^5.0.3"
@@ -8772,7 +8895,7 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-immediate-shim": {
@@ -8813,7 +8936,7 @@
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
         "shebang-regex": "^1.0.0"
@@ -8821,12 +8944,12 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-swizzle": {
@@ -9157,7 +9280,7 @@
     },
     "spdx-correct": {
       "version": "3.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -9166,12 +9289,12 @@
     },
     "spdx-exceptions": {
       "version": "2.2.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
       "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc="
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -9180,7 +9303,7 @@
     },
     "spdx-license-ids": {
       "version": "3.0.5",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ="
     },
     "spdy": {
@@ -9212,7 +9335,7 @@
     },
     "split": {
       "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/split/-/split-1.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/split/-/split-1.0.1.tgz",
       "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "requires": {
         "through": "2"
@@ -9228,7 +9351,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
@@ -9395,7 +9518,7 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-bom-stream": {
@@ -9419,12 +9542,12 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
       "version": "2.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-2.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-2.0.0.tgz",
       "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
     },
     "strip-json-comments": {
@@ -9442,7 +9565,7 @@
     },
     "supports-hyperlinks": {
       "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
       "integrity": "sha1-cdrt82zBBgrFEAw1G7PaSMKcDvc=",
       "requires": {
         "has-flag": "^2.0.0",
@@ -9451,7 +9574,7 @@
       "dependencies": {
         "has-flag": {
           "version": "2.0.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-2.0.0.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
         },
         "supports-color": {
@@ -9663,7 +9786,7 @@
     },
     "table": {
       "version": "5.4.6",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/table/-/table-5.4.6.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/table/-/table-5.4.6.tgz",
       "integrity": "sha1-EpLRlQDOP4YFOwXw6Ofko7shB54=",
       "dev": true,
       "requires": {
@@ -9825,7 +9948,7 @@
     },
     "term-size": {
       "version": "1.2.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/term-size/-/term-size-1.2.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "requires": {
         "execa": "^0.7.0"
@@ -9833,7 +9956,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "requires": {
             "lru-cache": "^4.0.1",
@@ -9843,7 +9966,7 @@
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/execa/-/execa-0.7.0.tgz",
+          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -9864,7 +9987,7 @@
     },
     "terminal-link": {
       "version": "1.3.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/terminal-link/-/terminal-link-1.3.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/terminal-link/-/terminal-link-1.3.0.tgz",
       "integrity": "sha1-PpowgonhM0AFOq9A6PGgbRM1ZG4=",
       "requires": {
         "ansi-escapes": "^3.2.0",
@@ -9904,7 +10027,7 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
@@ -9926,12 +10049,12 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through/-/through-2.3.8.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through2/-/through2-2.0.5.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2/-/through2-2.0.5.tgz",
       "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "requires": {
         "readable-stream": "~2.3.6",
@@ -9954,18 +10077,18 @@
     },
     "tiny-emitter": {
       "version": "2.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha1-HRpW7fxRxD6GPLtTgqcjMONVVCM=",
       "optional": true
     },
     "tlds": {
       "version": "1.207.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tlds/-/tlds-1.207.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tlds/-/tlds-1.207.0.tgz",
       "integrity": "sha1-RZJk5kTPY93All/s44mJEyhrGv0="
     },
     "tmp": {
       "version": "0.0.33",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tmp/-/tmp-0.0.33.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "requires": {
         "os-tmpdir": "~1.0.2"
@@ -10024,7 +10147,7 @@
     },
     "to-readable-stream": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
       "integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E="
     },
     "to-regex": {
@@ -10078,7 +10201,7 @@
     },
     "trim-newlines": {
       "version": "2.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-2.0.0.tgz",
       "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
     },
     "trim-right": {
@@ -10103,7 +10226,7 @@
     },
     "tslib": {
       "version": "1.10.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tslib/-/tslib-1.10.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha1-w8GflZc/sKYpc/sJ2Q2WHuQ+XIo="
     },
     "tunnel-agent": {
@@ -10121,7 +10244,7 @@
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -10135,7 +10258,7 @@
     },
     "type-fest": {
       "version": "0.8.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.8.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
       "dev": true
     },
@@ -10242,7 +10365,7 @@
     },
     "unique-string": {
       "version": "1.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unique-string/-/unique-string-1.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
         "crypto-random-string": "^1.0.0"
@@ -10304,7 +10427,7 @@
     },
     "update-notifier": {
       "version": "2.5.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-2.5.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-2.5.0.tgz",
       "integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
       "requires": {
         "boxen": "^1.2.1",
@@ -10326,7 +10449,7 @@
     },
     "uri-js": {
       "version": "4.2.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/uri-js/-/uri-js-4.2.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "requires": {
         "punycode": "^2.1.0"
@@ -10357,7 +10480,7 @@
     },
     "url-regex": {
       "version": "5.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/url-regex/-/url-regex-5.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-regex/-/url-regex-5.0.0.tgz",
       "integrity": "sha1-j1RWq4PYmNGLL5F1OnAmSbhzJzo=",
       "requires": {
         "ip-regex": "^4.1.0",
@@ -10390,7 +10513,7 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
@@ -10405,7 +10528,7 @@
     },
     "v8-compile-cache": {
       "version": "2.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
       "integrity": "sha1-4U3jezGm0ZT1aQ1n78Tn9vxqsw4=",
       "dev": true
     },
@@ -10416,7 +10539,7 @@
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "requires": {
         "spdx-correct": "^3.0.0",
@@ -10425,7 +10548,7 @@
     },
     "validate-npm-package-name": {
       "version": "3.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "requires": {
         "builtins": "^1.0.3"
@@ -10875,7 +10998,7 @@
     },
     "which": {
       "version": "1.3.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/which/-/which-1.3.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which/-/which-1.3.1.tgz",
       "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "requires": {
         "isexe": "^2.0.0"
@@ -10883,7 +11006,7 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wide-align": {
@@ -10896,7 +11019,7 @@
     },
     "widest-line": {
       "version": "2.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/widest-line/-/widest-line-2.0.1.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/widest-line/-/widest-line-2.0.1.tgz",
       "integrity": "sha1-dDh2RzDsfvQ4HOTfgvuYpTFCo/w=",
       "requires": {
         "string-width": "^2.1.1"
@@ -10958,7 +11081,7 @@
     },
     "word-wrap": {
       "version": "1.2.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/word-wrap/-/word-wrap-1.2.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
       "dev": true
     },
@@ -10985,7 +11108,7 @@
     },
     "wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "requires": {
         "ansi-styles": "^3.2.0",
@@ -11020,12 +11143,12 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/write/-/write-1.0.3.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/write/-/write-1.0.3.tgz",
       "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
       "dev": true,
       "requires": {
@@ -11034,7 +11157,7 @@
     },
     "write-file-atomic": {
       "version": "2.4.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
       "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -11049,7 +11172,7 @@
     },
     "xdg-basedir": {
       "version": "3.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
     },
     "xml2js": {
@@ -11079,12 +11202,12 @@
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xtend/-/xtend-4.0.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
     },
     "y18n": {
       "version": "4.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/y18n/-/y18n-4.0.0.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms="
     },
     "yallist": {
@@ -11094,7 +11217,7 @@
     },
     "yaml": {
       "version": "1.7.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yaml/-/yaml-1.7.2.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yaml/-/yaml-1.7.2.tgz",
       "integrity": "sha1-8mqr9zhZCrYe+spQI1jkjcnzSLI=",
       "requires": {
         "@babel/runtime": "^7.6.3"
@@ -11236,7 +11359,7 @@
     },
     "yargs-parser": {
       "version": "13.1.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "resolved": "http://artifactory-pr-build.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-13.1.1.tgz",
       "integrity": "sha1-0mBYUyqgbTZf4JH2ofwGsvfl7KA=",
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "np": "4.0.2",
     "prismjs": "1.17.1",
     "replace": "1.1.1",
+    "sass": "1.24.4",
     "selenium-webdriver": "4.0.0-alpha.5",
     "sinon": "7.5.0",
     "wct-browser-legacy": "1.0.2",


### PR DESCRIPTION
Ik heb hiervoor een werkend voorbeeld gevonden, maar nog een beetje hackish:
- De core wordt nu geïmporteerd in de demo.js maar die is geen dependency van vl-util.
- encodeHTML heb ik van het net geplukt: niet direct een betere manier gevonden