### PR TITLE
Overschakelen op ubuntu-node:14 base image

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -29,8 +29,8 @@ services:
       - no_proxy=${no_proxy},selenium-hub,tests
     shm_size: 2g
   tests:
-    image: ${DOCKER_REGISTRY}node:13
-    command: bash -c "apt-get update && apt-get install rsync -y && rsync -v -h -r --exclude 'node_modules' --exclude '.git' /data/. /workdir && npm install --verbose && npm run test:grid"
+    image: ${DOCKER_REGISTRY}milieuinfo/ubuntu-node:14
+    command: bash -c "rsync -v -h -r --exclude 'node_modules' /data/. /workdir && npm install --verbose && npm run test:grid"
     depends_on:
       - selenium-hub
       - selenium-chrome


### PR DESCRIPTION
Oorspronkelijk werd de officiële node image gebruikt voor de E2E testen. Deze image bevatte de `rsync` package niet. Om dit op te vangen werd er bij het opstarten van de node image telkens een update gedaan van alle packages via apt en vervolgens werd rsync geinstalleerd. Door nu gebruik te maken van een custom DIDM image (ubuntu-node) is het updaten en installeren van rsync niet meer nodig gezien laatstgenoemde image als beschikt over rsync.